### PR TITLE
Fix GPG key error in scripted installation of RVM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,8 @@
 $script_provision = <<SCRIPT
   echo Provisioning...
   
-  gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+  curl -#LO https://rvm.io/mpapis.asc
+  gpg --import mpapis.asc
   curl -sSL https://get.rvm.io | bash -s stable --rails
   source /usr/local/rvm/scripts/rvm
   


### PR DESCRIPTION
This problem appeared suddenly. For more info see https://github.com/rvm/rvm/issues/3110