### PR TITLE
Support triple backticks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,9 @@ highlighter: rouge
 permalink: /:year-:month-:day-:title/
 paginate: 5
 
+kramdown:
+  input: GFM
+
 # Default YAML values (more information on Jekyll's site)
 defaults:
   -


### PR DESCRIPTION
As mentioned in #55, this makes triple backticks work as expected.

Left is expected existing, right is expected new:

![image](https://cloud.githubusercontent.com/assets/1012917/15275604/33691dc8-1a9e-11e6-9f33-97ba9306bb58.png)
