### PR TITLE
Reset margin-top of <p>-in-<blockquote>

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -32,6 +32,9 @@ blockquote {
   color: #808080;
   font-style: italic;
 }
+blockquote p{
+  margin:0;
+}
 hr.small {
   max-width: 100px;
   margin: 15px auto;


### PR DESCRIPTION
In `main.css` file,`<p>` has a default margin top value-`30px`;it causes this result:if `<p>` is in `<blockquote>`,the default value makes the blockquote looks a little strange!       
So,I added `blockquote p{margin:0}` to `main.css` file!      
This is my first time to send pull request,hope I didn't make any mistakes!