### PR TITLE
Change order of post excerpt processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,23 +9,23 @@ subtitle: This is where I will tell my friends way too much about me
   <article class="post-preview">
     <a href="{{ post.url | prepend: site.baseurl }}">
 	  <h2 class="post-title">{{ post.title }}</h2>
-	
+
 	  {% if post.subtitle %}
 	  <h3 class="post-subtitle">
 	    {{ post.subtitle }}
 	  </h3>
-	  {% endif %}  
+	  {% endif %}
     </a>
 
     <p class="post-meta">
       Posted on {{ post.date | date: "%B %-d, %Y" }}
     </p>
-  
+
     <div class="post-entry">
-      {{ post.content | truncatewords: 50 | strip_html | xml_escape}}
+      {{ post.content | strip_html | xml_escape | truncatewords: 50 }}
 	  <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
     </div>
-  
+
    </article>
   {% endfor %}
 </div>


### PR DESCRIPTION
Since the truncate happens first, parts of HTML tags are cut in ways which will not be caught by the strip_html and xml_escape string filters. Switching the order of the filters fixes this issue. An example of this problem can be seen in the Test Mardown post.