### PR TITLE
Add styling for code blocks with line numbers

### DIFF
--- a/_posts/2015-02-20-test-markdown.md
+++ b/_posts/2015-02-20-test-markdown.md
@@ -39,3 +39,12 @@ var foo = function(x) {
 }
 foo(3)
 ```
+
+And here is some more with line numbers
+
+{% highlight python linenos %}
+def bar(x):
+    return x * 2
+
+print bar(2)
+{% endhighlight %}

--- a/css/main.css
+++ b/css/main.css
@@ -586,8 +586,9 @@ table tr td :last-child {
 }
 
 /* --- Code blocks --- */
+
 pre {
-  font-size: 16px;
+  font-size: 16px !important;
   line-height: 1.5em;
 }
 pre code {
@@ -601,27 +602,20 @@ pre.highlight, .highlight > pre, td.code pre {
   background-position: 0px 10px;
   border-left: 7px solid #444;
 }
+code table, code table td, code table th, code table tbody, code table tr,
+td.gutter pre {
+  padding: 0;
+  border: none;
+}
 .highlight > pre {
   padding: 0;
-  margin: 0;
 }
 td.code pre {
-  border: none;
-  border-left: 2px solid #444;
+  border-width: 0 0 0 2px;
+  border-style: solid;
+  border-color: #444;
   border-radius: 0;
-  background: transparent!;
-}
-td.gutter pre {
-  border: none;
 }
 td.gutter {
   padding-top: 3px;
-}
-code table {
-  border-collapse: collapse;
-  border: none;
-}
-code table td, code table th, code table tbody, code table tr {
-  padding: 0;
-  border: none;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -586,18 +586,42 @@ table tr td :last-child {
 }
 
 /* --- Code blocks --- */
-
 pre {
   font-size: 16px;
   line-height: 1.5em;
-  background: #FAFAFA;
-  background-image: linear-gradient(#FAFAFA 50%, #FDFDFD 50%);
-  background-position: 0px 10px;
-  background-repeat: repeat;
-  background-size: 3em 3em;
-  border-left: 7px solid #444;
 }
-
 pre code {
   white-space: pre;
+}
+pre.highlight, .highlight > pre, td.code pre {
+  background: #FAFAFA;
+  background-image: linear-gradient(#F9F9F9 50%, #FDFDFD 50%);
+  background-repeat: repeat;
+  background-size: 3em 3em;
+  background-position: 0px 10px;
+  border-left: 7px solid #444;
+}
+.highlight > pre {
+  padding: 0;
+  margin: 0;
+}
+td.code pre {
+  border: none;
+  border-left: 2px solid #444;
+  border-radius: 0;
+  background: transparent!;
+}
+td.gutter pre {
+  border: none;
+}
+td.gutter {
+  padding-top: 3px;
+}
+code table {
+  border-collapse: collapse;
+  border: none;
+}
+code table td, code table th, code table tbody, code table tr {
+  padding: 0;
+  border: none;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -588,7 +588,7 @@ table tr td :last-child {
 /* --- Code blocks --- */
 
 pre {
-  font-size: 16px !important;
+  font-size: 16px;
   line-height: 1.5em;
 }
 pre code {

--- a/css/pygment_highlights.css
+++ b/css/pygment_highlights.css
@@ -1,5 +1,5 @@
 /* .highlight  { background: #ffffff; } Dean commented out */
-.highlight pre { background-color: #fff; font-size: 16px }
+/* .highlight pre { background-color: #fff; font-size: 16px } */
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */


### PR DESCRIPTION
I created similar styling for code blocks with line numbers. The styling for code blocks without line numbers should be the same.

<img width="833" alt="code" src="https://cloud.githubusercontent.com/assets/8812459/17236347/04ff7f72-550e-11e6-8fe3-e2be468fc61d.png">
