### PR TITLE
Change footer position to relative

### DIFF
--- a/css/main-minimal.css
+++ b/css/main-minimal.css
@@ -3,7 +3,7 @@
 }
 
 footer.footer-min {
-  position: fixed;
+  position: relative;
   bottom: 0;
   width: 100%;
   padding: 3px;


### PR DESCRIPTION
Fixed position was causing the footer to cover content at the bottom of the page.