### PR TITLE
use post.excerpt instead of post.content

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ subtitle: This is where I will tell my friends way too much about me
     </p>
 
     <div class="post-entry">
-      {{ post.content | strip_html | xml_escape | truncatewords: 50 }}
+      {{ post.excerpt | strip_html | xml_escape | truncatewords: 50 }}
 	  <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
     </div>
 


### PR DESCRIPTION
In index.html, there is a line for post excerpts:
```
      {{ post.content | strip_html | xml_escape | truncatewords: 50 }}
```
But Chinese and Japanese don't contain spaces in articles, so it's not possible to truncate 50 words from that kind of posts.

![image](https://cloud.githubusercontent.com/assets/441707/18558106/64a666f4-7ba4-11e6-9d61-451f565246df.png)

I made a test shown in the image. If there aren't enough spaces in Chinese posts, the whole article is used as the excerpt.
 
Would you consider using [post.excerpt](https://jekyllrb.com/docs/posts/#post-excerpts) instead?
```
      {{ post.excerpt | strip_html | xml_escape | truncatewords: 50 }}
```

This is how it looks.

![image](https://cloud.githubusercontent.com/assets/441707/18558184/bbf7d83e-7ba4-11e6-819c-4ac057da06cc.png)