### PR TITLE
Fix show/hide of Read Me link on index page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,10 @@ url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 # Facebook App ID
 # fb_app_id: ""
 
+# Excerpt Word Length
+# Truncates the excerpt to the specified number of words on the index page
+excerpt_length: 50
+
 # --- Don't need to touch anything below here (but you can if you want) --- #
 
 # Output options (more information on Jekyll's site)

--- a/index.html
+++ b/index.html
@@ -22,19 +22,16 @@ subtitle: This is where I will tell my friends way too much about me
     </p>
 
     <div class="post-entry">
-      {% assign cleaned_content = post.excerpt | strip_html | xml_escape %}
-      {% assign truncated_content = cleaned_content | truncatewords: 50 %}
-      {% if truncated_content == cleaned_content %}
-        {{ cleaned_content }}
-      {% else %}
-        {{ truncated_content }}
+      {{ post.excerpt | strip_html | xml_escape | truncatewords: site.excerpt_length }}
+      {% assign excerpt_word_count = post.excerpt | number_of_words %}
+      {% if post.content != post.excerpt or excerpt_word_count > site.excerpt_length %}
         <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
-      {% endif%}
+      {% endif %}
     </div>
 
     {% if post.tags.size > 0 %}
     <div class="blog-tags">
-      Tags: 
+      Tags:
       {% if site.link-tags %}
       {% for tag in post.tags %}
       <a href="{{ site.baseurl }}/tag/{{ tag }}">{{ tag }}</a>


### PR DESCRIPTION
Uses the excerpt only to a maximum number of words on the index page. Moved out maximum number of excerpt words value to configuration.