### PR TITLE
quickfix to run blog on localhost without changing _config.yml

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,1 @@
+url: "http://localhost:4000"

--- a/serve
+++ b/serve
@@ -1,0 +1,1 @@
+bundle exec jekyll serve --config _config.yml,_config_dev.yml


### PR DESCRIPTION
This uses addtional _config_dev.yml which sets
`url: "http://localhost:4000"`
So you can run the blog on your local pc without changing the original _config.yml.

Use with this command(the serve file):
`bundle exec jekyll serve --config _config.yml,_config_dev.yml`

To use the shortcut, make the script executable:
`chmod +x serve`
And then run it
`./serve`

Congrats, you run now your jekyll site locally without needing to change _config.yml to point it out to localhost!
