### PR TITLE
Fixed: Post image hides posts' date

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -351,7 +351,7 @@ footer .theme-by {
   float: right;
   height: 192px;
   width: 192px;
-  margin-top: -35px;
+  margin-top: -13px;
   filter: grayscale(90%);
 }
 .post-image:hover {


### PR DESCRIPTION
Hi, I was implementing these changes on my site, I noticed that post image was hiding/covering the post's dates (mostly the year) when viewed on small screen devices.
-13px seems to work (not getting much drifted away when viewing on desktop layout), I hope it's fine, I guess you have something else in mind to fix this.
Thanks.