### PR TITLE
Add Google Tag Manager Integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -95,6 +95,9 @@ url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 # Fill in your Google Analytics ID to track your website using GA
 #google_analytics: ""
 
+# Google Tag Manager ID
+#gtm: ""
+
 # Facebook App ID
 # fb_app_id: ""
 

--- a/_includes/gtm_body.html
+++ b/_includes/gtm_body.html
@@ -1,0 +1,6 @@
+{% if site.gtm %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.gtm }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+{% endif %}

--- a/_includes/gtm_head.html
+++ b/_includes/gtm_head.html
@@ -1,0 +1,9 @@
+{% if site.gtm %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ site.gtm }}');</script>
+    <!-- End Google Tag Manager -->
+{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,8 @@
 
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} {{ site.title-separator }} {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
+  {% include gtm_head.html %}
+
   {% if layout.common-ext-css %}
     {% for css in layout.common-ext-css %}
       <link rel="stylesheet" href="{{ css }}" />

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,6 +20,8 @@ common-js:
   {% include head.html %}
 
   <body>
+
+    {% include gtm_body.html %}
   
     {% include nav.html %}
 


### PR DESCRIPTION
Google Tag Manager (GTM) is commonly used for managing all Digital Analytics tracking solutions in one place.

It was recommended by GTM to add the `<script>` tag as high in the <head> of the page as possible, and to add `<noscript>` tag immediately after the opening <body> tag.