### PR TITLE
Add Subresource Integrity (SRI) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ social-share | If you don't want to show buttons to share a blog post on social 
 use-site-title | If you want to use the site title rather than page title as HTML document title (ie. browser tab title), use `use-site-title: true`. When set, the document title will take the format `Site Title - Site Description` (eg. `My website - A virtual proof that name is awesome!`). By default, it will use `Page Title` if it exists, or `Site Title` otherwise.
 layout      | What type of page this is (default is `blog` for blog posts and `page` for other pages. You can use `minimal` if you don't want a header and footer)  
 js          | List of local JavaScript files to include in the page (eg. `/js/mypage.js`)
-ext-js      | List of external JavaScript files to include in the page (eg. `//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.2/underscore-min.js`)
+ext-js      | List of external JavaScript files to include in the page (eg. `//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.2/underscore-min.js`). External JavaScript files that support [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) can be specified using the `href` and `sri` parameters eg.<br/>`href: "//code.jquery.com/jquery-3.1.1.min.js"`<br/>`sri: "sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="`
 css         | List of local CSS files to include in the page
-ex-css      | List of external CSS files to include in the page
+ext-css      | List of external CSS files to include in the page. External CSS files using SRI (see `ext-js` parameter) are also supported. 
 googlefonts | List of Google fonts to include in the page (eg. `["Monoton", "Lobster"]`)
 
 ### Advanced features (including how to use a custom URL address for your site)

--- a/_includes/ext-css.html
+++ b/_includes/ext-css.html
@@ -1,0 +1,7 @@
+{% if include.css.sri %}
+  <link href="{{ include.css.href }}" rel="stylesheet" integrity="{{ include.css.sri }}" crossorigin="anonymous">
+{% elsif include.css.href %}
+  <link rel="stylesheet" href="{{ include.css.href }}" />
+{% else %}
+  <link rel="stylesheet" href="{{ include.css }}" />
+{% endif %}

--- a/_includes/ext-js.html
+++ b/_includes/ext-js.html
@@ -1,0 +1,7 @@
+{% if include.js.sri %}
+  <script src="{{ include.js.href }}" integrity="{{ include.js.sri }}" crossorigin="anonymous"></script>
+{% elsif include.js.href %}
+  <script src="{{ include.js.href }}"></script>
+{% else %}
+  <script src="{{ include.js }}"></script>
+{% endif %}

--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -1,12 +1,12 @@
 {% if layout.common-ext-js %}
   {% for js in layout.common-ext-js %}
-	<script src="{{ js }}"></script>
+    {% include ext-js.html js=js %}
   {% endfor %}
 {% endif %}
 
 {% if page.ext-js %}
   {% for js in page.ext-js %}
-	<script src="{{ js }}"></script>
+    {% include ext-js.html js=js %}
   {% endfor %}
 {% endif %}
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
 
   {% if layout.common-ext-css %}
     {% for css in layout.common-ext-css %}
-      <link rel="stylesheet" href="{{ css }}" />
+      {% include ext-css.html css=css %}
     {% endfor %}
   {% endif %}
 
@@ -35,7 +35,7 @@
 
   {% if page.ext-css %}
     {% for css in page.ext-css %}
-      <link rel="stylesheet" href="{{ css }}" />
+      {% include ext-css.html css=css %}
     {% endfor %}
   {% endif %}
 


### PR DESCRIPTION
Modify `ext-js` and `ext-css` YAML front matter parameters to take
`href` and `sri` values. If `sri` is set, add to integrity attribute on
script/link element loading external JavaScript/CSS.

Existing behaviour is maintained if `href`/`sri` are not used.

For more information on SRI, see:
https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity