### PR TITLE
Update json gem to 2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
-    json (1.8.3)
+    json (2.1.0)
     kramdown (1.11.1)
     liquid (3.0.6)
     listen (3.0.6)


### PR DESCRIPTION
When building locally, json 1.8.3 fails to install when running bundle install. Version 2.1.0 works.