### PR TITLE
Changing og:image to absolute URL

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -84,7 +84,7 @@
   {% endif %}
 
   {% if page.share-img %}
-  <meta property="og:image" content="{{ page.share-img }}" />
+  <meta property="og:image" content="{{ site.url }}{{ page.share-img }}" />
   {% elsif site.avatar %}
   <meta property="og:image" content="{{ site.url }}{{ site.avatar }}" />
   {% endif %}
@@ -112,7 +112,7 @@
   {% endif %}
 
   {% if page.share-img %}
-  <meta name="twitter:image" content="{{ page.share-img }}" />
+  <meta name="twitter:image" content="{{ site.url }}{{ page.share-img }}" />
   {% elsif site.avatar %}
   <meta name="twitter:image" content="{{ site.url }}{{ site.avatar }}" />
   {% endif %}


### PR DESCRIPTION
Relative URL can cause problems with some website. Absolute URLs are recommended.