### PR TITLE
Remove :focus and :hover rules from .navbar-toggle

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -741,3 +741,14 @@ td.gutter {
 .gist, .gist-file table tr td {
   border: unset;
 }
+
+/* fix .navbar-toggle */
+
+.navbar-default button.navbar-toggle:focus,
+.navbar-default button.navbar-toggle:hover {
+  background-color: initial;
+}
+
+.navbar-default button.navbar-toggle[aria-expanded="true"] {
+  background-color: #ddd;
+}


### PR DESCRIPTION
fixes #268

- clear `:focus` rule - prevent #ddd color linger on desktop
- clear `:hover` rule - prevent #ddd color linger on touchscreen
- add `aria-expanded="true"` rule - set #ddd color when expanded

after merging, I'll work on #256 