### PR TITLE
More color personalization options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-# CHANGELOG
+ # CHANGELOG
 
 This file lists all non-trivial changes to Beautiful Jekyll.
 
 I often make small changes to documentation, to the demo site, or to the general look-and-feel. These changes will not be listed here. Any other minor changes will also not be listed here.
+
+**2018-01-06** More color personalization options (#297 and #298) (thanks @jennydaman)
 
 **2018-01-05** Abstract the social networks logic (thanks @OCram85)
 
@@ -28,7 +30,7 @@ I often make small changes to documentation, to the demo site, or to the general
 
 **2016-12-25** Allow dynamic images on each blog post (#143) (thanks @bbritten)
 
-**2016-12-15** Support `title-img` config param to have image in the navbar instead of text 
+**2016-12-15** Support `title-img` config param to have image in the navbar instead of text
 
 **2016-12-08** Add support for phone numbers in footer; fix #136
 
@@ -50,7 +52,7 @@ I often make small changes to documentation, to the demo site, or to the general
 
 **2016-02-07** Avatar is now conditional (thanks @hristoyankov)
 
-**2016-02-02** Migrate (forced to...) to jekyll 3 
+**2016-02-02** Migrate (forced to...) to jekyll 3
 
 **2016-01-22** Make sure not to include JQuery twice, fixes #29
 

--- a/_config.yml
+++ b/_config.yml
@@ -43,12 +43,15 @@ avatar: "/img/avatar-icon.png"
 # By default, the navigation bar and footer have a light gray background, and the main page
 # has a white background. You can specify a different background colour or a background image
 # for the navigation bar, the main page, and the footer.
-# navbar-col: "orange"
+# navbar-col: "linear-gradient(to top left, #333399 0%, #9966ff 100%);" # go crazy :)
+# navbar-text-col: "#EEEEEE"
+# navbar-children-col: "#333399"
 # navbar-img: "/img/bgimage.png"
 # footer-col: "blue"
 # footer-img: "/img/bgimage.png"
 # page-col: "#FF0000"
 # page-img: "/img/bgimage.png"
+# hover-col: "pink"
 
 # --- Footer options --- #
 

--- a/css/main.css
+++ b/css/main.css
@@ -24,10 +24,6 @@ p {
   line-height: 1.5;
   margin: 30px 0;
 }
-p a {
-  /* text-decoration: underline */
-  color: #008AFF;
-}
 h1,h2,h3,h4,h5,h6 {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 800;
@@ -38,6 +34,9 @@ a {
 a:hover,
 a:focus {
   color: #0085a1;
+  {% if site.hover-col %}
+  color: {{ site.hover-col }};
+  {% endif %}
 }
 blockquote {
   color: #808080;
@@ -76,11 +75,17 @@ hr.small {
   color: white;
   text-shadow: none;
   background: #0085a1;
+  {% if site.hover-col %}
+  background: {{ site.hover-col }};
+  {% endif %}
 }
 ::selection {
   color: white;
   text-shadow: none;
   background: #0085a1;
+  {% if site.hover-col %}
+  background: {{ site.hover-col }};
+  {% endif %}
 }
 img::selection {
   color: white;
@@ -130,6 +135,9 @@ img {
 .navbar-custom .nav li a {
   font-weight: 800;
   color: #404040;
+  {% if site.navbar-text-col %}
+  color: {{ site.navbar-text-col }};
+  {% endif %}
 }
 
 .navbar-custom .navbar-brand:hover,
@@ -137,6 +145,9 @@ img {
 .navbar-custom .nav li a:hover,
 .navbar-custom .nav li a:focus {
   color: #0085a1;
+  {% if site.hover-col %}
+  color: {{ site.hover-col }};
+  {% endif %}
 }
 
 .navbar-custom .navbar-brand-logo {
@@ -231,6 +242,9 @@ img {
   padding: 10px;
   padding-left: 30px;
   background: #f5f5f5;
+  {% if site.navbar-children-col %}
+  background: {{ site.navbar-children-col }};
+  {% endif %}
   text-decoration: none !important;
   border-width: 0 1px 1px 1px;
   font-weight: normal;
@@ -249,6 +263,11 @@ img {
   }
   .navbar-custom .nav .navlinks-container:hover {
     background: #eee;
+    {% if site.navbar-col %}
+    background: {{ site.navbar-col }};
+    outline: 1px #eaeaea solid;
+    background: rgba(0, 0, 0, -0.1);
+    {% endif %}
   }
   .navbar-custom .nav .navlinks-container:hover .navlinks-children {
     display: block;
@@ -336,6 +355,9 @@ footer .theme-by {
 .post-preview a:hover {
   text-decoration: none;
   color: #0085a1;
+  {% if site.hover-col %}
+  color: {{ site.hover-col }};
+  {% endif %}
 }
 
 .post-preview .post-title {
@@ -400,6 +422,9 @@ footer .theme-by {
 
 .blog-tags a {
   color: #008AFF;
+  {% if site.hover-col %}
+  color: {{ site.hover-col }};
+  {% endif %}
   text-decoration: none;
   padding: 0px 5px;
 }
@@ -407,6 +432,9 @@ footer .theme-by {
 .blog-tags a:hover {
   border-radius: 2px;
   color: #008AFF;
+  {% if site.hover-col %}
+  color: {{ site.hover-col }};
+  {% endif %}
   background-color: #CCC;
 }
 
@@ -614,6 +642,10 @@ footer .theme-by {
   color: #FFF;
   background: #0085a1;
   border: 1px solid #0085a1;
+  {% if site.hover-col %}
+  background: {{ site.hover-col }};
+  border-color: {{ site.hover-col }};
+  {% endif %}
 }
 
 .pager {

--- a/css/main.css
+++ b/css/main.css
@@ -750,5 +750,5 @@ td.gutter {
 }
 
 .navbar-default button.navbar-toggle[aria-expanded="true"] {
-  background-color: #ddd;
+  background-color: rgba(0, 0, 0, .2);
 }


### PR DESCRIPTION
#256

I'm happy with these commits, though not everything has been dealt with yet.

I've created the option to set `navbar-text-col` but not footer text color (yet). Footer text color is determined by the class `text-muted`. The footer is the only place where this class is used. Is it okay to create a Jekyll variable with the name `footer-text-col` and have the setting injected into `text-muted`?

Moreover, the option to set `page-text-col` is missing as well. (it might be a good option if someone chooses an atrocious background color, like `page-col: "#FF0000"`. Implementation of `page-text-col` might be messy, since there's so many different elements to account for. But I can figure it out if you think it's a good idea.

Those are just concerns, however. This PR is ready to be merged after review.