### PR TITLE
Simplify Docker use :whale:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file lists all non-trivial changes to Beautiful Jekyll.
 
 I often make small changes to documentation, to the demo site, or to the general look-and-feel. These changes will not be listed here. Any other minor changes will also not be listed here.
 
+**2018-01-14** Redo Dockerfile (#302) (thanks @jennydaman)
+
 **2018-01-06** More color personalization options (#297 and #299) (thanks @jennydaman)
 
 **2018-01-05** Abstract the social networks logic (thanks @OCram85)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,14 @@
-FROM mangar/jekyll:1.0
+FROM jekyll/jekyll
 
-MAINTAINER Marcio Mangar "marcio.mangar@gmail.com"
+WORKDIR /srv/jekyll
+COPY Gemfile .
 
-RUN gem install jekyll -v 3.1.6
 RUN gem install bundler
-
-RUN gem install execjs
-RUN gem install therubyracer
-RUN gem install github-pages
-RUN gem install jekyll-paginate
-RUN gem install jekyll-seo-tag
-RUN gem install jekyll-gist
-RUN gem install json -v 1.8.3
-
-RUN gem install minitest -v 5.9.0
-RUN gem install colorator -v 0.1
-RUN gem install ffi -v 1.9.10
-RUN gem install kramdown -v 1.10.0
-RUN gem install rouge -v 1.10.1
-RUN gem install pkg-config -v 1.1.7
-RUN gem install terminal-table -v 1.6.0
-RUN gem install ethon -v 0.9.0
-RUN gem install nokogiri -v 1.6.8
-RUN gem install activesupport -v 4.2.6
-RUN gem install html-pipeline -v 2.4.1
-RUN gem install jekyll-watch -v 1.4.0
-RUN gem install github-pages-health-check -v 1.1.0
-RUN gem install jekyll-github-metadata -v 2.0.0
-RUN gem install jekyll-mentions -v 1.1.2
-RUN gem install jekyll-redirect-from -v 0.10.0
-RUN gem install jemoji -v 0.6.2
-RUN gem install github-pages -v 82
-
-
-
-RUN mkdir -p /app
-ADD ./ /app
-
-WORKDIR /app
+RUN bundle install --clean --quiet
 
 EXPOSE 4000
 
-CMD bundle exec jekyll serve
+# See https://github.com/daattali/beautiful-jekyll/issues/302#issuecomment-357528536
+CMD [ "/usr/gem/bin/bundle", "exec", "/usr/local/bundle/bin/jekyll", "serve", "--port", "4000", "--host", "0.0.0.0" ]
+
+STOPSIGNAL 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN bundle install --clean --quiet
 
 EXPOSE 4000
 
-# See https://github.com/daattali/beautiful-jekyll/issues/302#issuecomment-357528536
 CMD [ "/usr/gem/bin/bundle", "exec", "/usr/local/bundle/bin/jekyll", "serve", "--port", "4000", "--host", "0.0.0.0" ]
 
 STOPSIGNAL 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,12 +13,13 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    ethon (0.10.1)
+    concurrent-ruby (1.0.5)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18-x64-mingw32)
+    ffi (1.9.18)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (163)
@@ -72,7 +73,8 @@ GEM
     html-pipeline (2.7.1)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    i18n (0.8.6)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
     jekyll (3.5.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -160,8 +162,8 @@ GEM
       jekyll-seo-tag (~> 2.0)
     jekyll-titles-from-headings (0.4.0)
       jekyll (~> 3.3)
-    jekyll-watch (1.5.0)
-      listen (~> 3.0, < 3.1)
+    jekyll-watch (1.5.1)
+      listen (~> 3.0)
     jemoji (0.8.1)
       activesupport (~> 4.0, >= 4.2.9)
       gemoji (~> 3.0)
@@ -176,14 +178,14 @@ GEM
     mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
-    minitest (5.10.3)
+    minitest (5.11.1)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.1-x64-mingw32)
+    nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    octokit (4.7.0)
+    octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    pathutil (0.16.0)
+    pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
     rb-fsevent (0.10.2)
@@ -191,7 +193,7 @@ GEM
       ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.5.2)
+    sass (3.5.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -204,16 +206,16 @@ GEM
     thread_safe (0.3.6)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
 
 PLATFORMS
-  x64-mingw32
+  ruby
 
 DEPENDENCIES
   github-pages (= 163)
   jekyll-paginate
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -209,16 +209,40 @@ Beautiful Jekyll is meant to be so simple to use that you can do it all within t
 
 1. Make sure that you have Docker installed on your local environment. Installation instructions can be found [here](https://docs.docker.com/engine/installation/)
 2. Clone your fork `git clone git@github.com:yourusername/yourusername.github.io.git`
-3. Inside your repository folder, run:
+3. Build the docker image
 
-    ```
-    docker run -p 4000:4000 -v `pwd`:/app mangar/jekyll:1.1 bash -c "bundle install; bundle exec jekyll serve"
-    ```
-    Note you may need to add `--host 0.0.0.0` after `bundle exec jekyll serve` to get the site to server correctly.
-4. View your website at <http://localhost:4000>.
+```bash
+docker build -t beautiful-jekyll $PWD
+```
 
-Disclaimer: I personally am NOT using local development so I don't know much about running Jekyll locally. If you follow this route, please don't ask me questions because unfortunately I honestly won't be able to help!		
-  		  
+4. Start the container for the first time
+
+```bash
+docker run -d -p 4000:4000 --name beautiful-jekyll -v $PWD:/srv/jekyll beautiful-jekyll
+```
+
+5. View your website at <http://localhost:4000>.
+
+After the container is running, you can stop the server simply with the command
+
+```bash
+docker stop beautiful-jekyll
+```
+
+To start a container again (after you've already created it)
+
+```bash
+docker start beautiful-jekyll
+```
+
+If you change `_config.yml`, you must restart the server for jekyll to rebuild the site.
+
+```bash
+docker restart beautiful-jekyll
+```
+
+Disclaimer: I personally am NOT using local development so I don't know much about running Jekyll locally. If you follow this route, please don't ask me questions because unfortunately I honestly won't be able to help!
+
 Aditionally, if you choose to deploy Jekyll using a local ruby installation, you can tell Jekyll to automatically categorize your blog posts by tags. You just need to set `link-tags: true` in `_config.yml`. Jekyll will then generate a new page for each unique tag which lists all of the posts that belong to that tag.
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -205,23 +205,26 @@ Want your website featured here? [Contact me](http://deanattali.com/aboutme#cont
 
 ## Advanced: Local development using Docker
 
-Beautiful Jekyll is meant to be so simple to use that you can do it all within the browser. However, if you'd like to develop locally on your own machine, that's possible too if you're comfortable with command line. Follow these simple steps to do that with Docker:
-
-1. Make sure that you have Docker installed on your local environment. Installation instructions can be found [here](https://docs.docker.com/engine/installation/)
-2. Clone your fork `git clone git@github.com:yourusername/yourusername.github.io.git`
-3. Build the docker image
+First, clone your repository locally.
 
 ```bash
-docker build -t beautiful-jekyll $PWD
+git clone https://github.com/<your_username>/<your_username>.github.io.git
 ```
 
-4. Start the container for the first time
+Make sure you have Docker installed. https://www.docker.com/community-edition
+
+### First-time setup
 
 ```bash
+# 1. change directory
+cd <folder>
+# 2. Build the docker image
+docker build -t beautiful-jekyll $PWD
+# 3. Start the container for the first time
 docker run -d -p 4000:4000 --name beautiful-jekyll -v $PWD:/srv/jekyll beautiful-jekyll
 ```
 
-5. View your website at <http://localhost:4000>.
+You can now view your website at http://localhost:4000/.
 
 After the container is running, you can stop the server simply with the command
 


### PR DESCRIPTION
Conversation here: https://github.com/daattali/beautiful-jekyll/issues/302#issuecomment-357528536

In jennydaman/beautiful-jekyll, I have to branches. :readme-dock is upstream to :dock. All I changed was the wording of README.md to match my taste. If you don't like it, I'll open a PR for :dock instead.

https://github.com/jennydaman/beautiful-jekyll/compare/dock...jennydaman:readme-dock

Unrelated: In my last PR I added a comment that suggests CSS gradients can be used as colors. That's true, and it looks slick. https://twlinux.github.io/
Unfortunately, it turns out replacing `background` with `background-color` removes compatibility with gradients. Oops. Do you want me to change that?