### PR TITLE
Adds Matomo (aka Piwik) integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,15 +101,29 @@ share-links-active:
 # Remove this if you don't want a link in the footer
 url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 
-# --- Misc --- #
-# Fill in your Disqus shortname (NOT the userid) if you want to support Disqus comments
-#disqus: ""
+# --- Web Statistics Section --- #
+# ...Beautiful Jekyll integrates with Google Analytics and Matomo(aka Piwik)
 
 # Fill in your Google Analytics ID to track your website using GA
 #google_analytics: ""
 
 # Google Tag Manager ID
 #gtm: ""
+
+# Matomo (aka Piwik) Web statistics
+# Uncomment this Matomo options to enable tacking:
+# - Provide a valid site id given by your Matomo instance.
+# - Enter the Matomo URI without the protocoll.
+# - Enable/ Disable the Opt-Out feature for users. This will ad a Do-Not-Track option in the footer section.
+
+#  matomo:
+#    site_id: "9"
+#    uri: "demo.wiki.pro"
+#    opt-out: true
+
+# --- Misc --- #
+# Fill in your Disqus shortname (NOT the userid) if you want to support Disqus comments
+#disqus: ""
 
 # Facebook App ID
 # fb_app_id: ""

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,6 +32,13 @@
       &nbsp;&bull;&nbsp;
       <a href="{{ site.url }}">{{ site.url-pretty }}</a>
       {% endif %}
+
+      {% if site.matomo %}
+      &nbsp;&bull;&nbsp;
+        {% if site.matomo.opt-out %}
+          <a href="http://{{- site.matomo.uri -}}/index.php?module=CoreAdminHome&action=optOut" target="_blank" class="text_muted">Do-not-Track</a>
+        {% endif %}
+      {% endif%}
       </p>
           <!-- Please don't remove this, keep my open source work credited :) -->
     <p class="theme-by text-muted">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -88,7 +88,7 @@
   {% elsif site.avatar %}
   <meta property="og:image" content="{{ site.url }}{{ site.avatar }}" />
   {% endif %}
-  
+
 
   <!-- Twitter summary cards -->
   <meta name="twitter:card" content="summary" />
@@ -115,6 +115,10 @@
   <meta name="twitter:image" content="{{ page.share-img }}" />
   {% elsif site.avatar %}
   <meta name="twitter:image" content="{{ site.url }}{{ site.avatar }}" />
+  {% endif %}
+
+  {% if site.matomo %}
+  {% include matomo.html %}
   {% endif %}
 
 </head>

--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -1,0 +1,17 @@
+{% if site.matomo %}
+  <!-- Matomo -->
+  <script type="text/javascript">
+    var _paq = _paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//{{- site.matomo.uri -}}/";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', '{{- site.matomo.site_id -}}']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Piwik Code -->
+{% endif %}


### PR DESCRIPTION
## :question: About
Some users don't like using Google Analytics. Alternatively they use the open-source tracking suite Matomo (aka Piwik). I added 3 simple config keys to set up the tracking with an existing Matomo instance.

All you need is:

- Matomo Site ID
- Matomo Instance URI
- Enable / Disable the Opt-Out feature.

## :notebook: Changes
- Restructured the config keys section in `_config.yml`. There is now a dedicated *Web Statistics Section*
  - contains Google and Matomo preferences
- added `matomo.html` include file with the JS tracking code
- added Do-Not-Track link in footer if Opt-Out is set. This will open a new page in the browser language.
- tracking code in header headed if keys set.

## :bulb: Improvements
@daattali : Maybe you have got an other idea where and how to add the Do-Not-Track link.

## :link: Ref
fixes #309 