### PR TITLE
Even simpler Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM jekyll/jekyll
 
-WORKDIR /srv/jekyll
 COPY Gemfile .
 COPY Gemfile.lock .
 
-RUN gem install bundler
 RUN bundle install --quiet --clean
 
-EXPOSE 4000
-
-ENTRYPOINT ["jekyll", "serve"]
+CMD ["jekyll", "serve"]


### PR DESCRIPTION
Just technicalities for the die-hard perfectionist...

The Dockerfile from the image jekyll/jekyll is here: https://github.com/envygeeks/jekyll-docker/blob/d056a3bfa57763b3d1717aeb2ad1972c7d05b3b9/repos/jekyll/Dockerfile

So many configurations in our Dockerfile are inherited, making the lines I have removed unnecessary.

The issue concerning dependencies is resolved by ` COPY Gemfile.lock .`

It is preferable to define `CMD` instead of `ENTRYPOINT` because of [this wrapper script](https://github.com/envygeeks/jekyll-docker/blob/d056a3bfa57763b3d1717aeb2ad1972c7d05b3b9/repos/jekyll/Dockerfile#L171-L172).