### PR TITLE
Readme.md: fix instructions for dirs with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Beautiful Jekyll is meant to be so simple to use that you can do it all within t
 
     ```bash
     cd <repository_folder>
-    docker build -t beautiful-jekyll $PWD
-    docker run -d -p 4000:4000 --name beautiful-jekyll -v $PWD:/srv/jekyll beautiful-jekyll
+    docker build -t beautiful-jekyll "$PWD"
+    docker run -d -p 4000:4000 --name beautiful-jekyll -v "$PWD":/srv/jekyll beautiful-jekyll
     ```
 
 


### PR DESCRIPTION
$PWD needs to be surrounded in quotes so that the commands work when any folder in the path has a space in it.

Currently if someone runs the command as-is, and their folder path has a space in it, they will get the build error message `"docker build" requires exactly 1 argument` build and run error message `docker: invalid reference format` during run.