### PR TITLE
Add gtag support for Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,6 +103,9 @@ url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 
 # --- Web Statistics Section --- #
 
+# Fill in your Google Analytics gtag.js ID to track your website using gtag
+#gtag: ""
+
 # Fill in your Google Analytics ID to track your website using GA
 #google_analytics: ""
 

--- a/_includes/gtag.html
+++ b/_includes/gtag.html
@@ -1,0 +1,11 @@
+{% if site.gtag %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.gtag }}"></script>
+    <script>
+          window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.gtag }}');
+</script>
+{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,7 @@
 
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} {{ site.title-separator }} {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
+  {% include gtag.html %}
   {% include gtm_head.html %}
 
   {% if layout.common-ext-css %}


### PR DESCRIPTION
Google Analytics has a new type of default `<script>` tag called `gtag`. This PR adds support for that. 