### PR TITLE
text-alignment option for -layout (pages and post)

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@ layout: base
 
 {% include header.html type="page" %}
 
-<div class="container" role="main">
+<div class="container" role="main" style="text-align: justify;">
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
       {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: base
 
 {% include header.html type="post" %}
 
-<div class="container">
+<div class="container" style="text-align: justify;">
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 


### PR DESCRIPTION
Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!

Thank you for the great package. As I couldn't find the proper param for setting the text alignment for different pages, I added the text-alignment option for page.html and post.html and set the default to 'justify' which makes the text more clean and readable, especially for the blogs. I preferred a local setting than set a global variable for it in the config file. 

Hope it would be useful for others.
