### PR TITLE
Update Jekyll requirements: old {%- format support was removed + site…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -237,9 +237,11 @@ prose:
           label: "Publish"
           help: "Check to publish post, uncheck to hide."
 
+plugins_dir:
+  - jekyll-sitemap
+
 plugins:
   - jekyll-paginate
-  - jekyll-sitemap
 
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189

--- a/_includes/fb-comment.html
+++ b/_includes/fb-comment.html
@@ -1,4 +1,4 @@
-{%- if site.fb_comment_id -%}
+{% if site.fb_comment_id %}
 <div class="comments">
     <div id="fb-root"></div>
     <script>(function(d, s, id) {
@@ -11,4 +11,4 @@
     <div class="fb-comments" data-href="{{ site.url }}{{ page.url }}" data-width="100%" data-numposts="5"></div>
     <noscript>Please enable JavaScript to view the comments powered by Facebook.</noscript>
 </div>
-{%- endif -%}
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,17 +3,17 @@
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
         <ul class="list-inline text-center footer-links">
-          {%- for link in site.social-network-links -%}
-            {%- assign curkey = link[0] -%}
-            {%- assign element = site.data.SocialNetworks[curkey] -%}
+          {% for link in site.social-network-links %}
+            {% assign curkey = link[0] %}
+            {% assign element = site.data.SocialNetworks[curkey] %}
             <li>
-            {%- if curkey == 'rss' -%}
+            {% if curkey == 'rss' %}
               <a href="{{ '/feed.xml' | prepend: site.baseurl }}" title="{{ element.name }}">
-            {%- elsif curkey == 'yelp' -%}
+            {% elsif curkey == 'yelp' %}
               <a href="https://{{ site.social-network-links[curkey] }}.yelp.com" title="{{ element.name }}">
-            {%- else -%}
+            {% else %}
               <a href="{{element.baseURL}}{{ site.social-network-links[curkey] }}" title="{{ element.name }}">
-            {%- endif -%}
+            {% endif %}
                 <span class="fa-stack fa-lg" aria-hidden="true">
                   <i class="fa fa-circle fa-stack-2x"></i>
                   <i class="fa {{ element.icon }} fa-stack-1x fa-inverse"></i>
@@ -21,7 +21,7 @@
                 <span class="sr-only">{{ element.name }}</span>
               </a>
             </li>
-          {%- endfor -%}
+          {% endfor %}
         </ul>
       <p class="copyright text-muted">
       {{ site.author.name }}

--- a/tags.html
+++ b/tags.html
@@ -3,32 +3,32 @@ layout: page
 title: 'Tag Index'
 ---
 
-{%- capture site_tags -%}
-    {%- for tag in site.tags -%}
-        {{- tag | first -}}{%- unless forloop.last -%},{%- endunless -%}
-    {%- endfor -%}
-{%- endcapture -%}
-{%- assign tags_list = site_tags | split:',' | sort -%}
+{% capture site_tags %}
+    {% for tag in site.tags %}
+        {{- tag | first -}}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+{% endcapture %}
+{% assign tags_list = site_tags | split:',' | sort %}
 
-{%- for tag in tags_list -%}
+{% for tag in tags_list %}
     <a href="#{{- tag -}}" class="btn btn-primary tag-btn"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{- tag -}}&nbsp;({{site.tags[tag].size}})</a>
-{%- endfor -%}
+{% endfor %}
 
 <div id="full-tags-list">
-{%- for tag in tags_list -%}
+{% for tag in tags_list %}
     <h2 id="{{- tag -}}" class="linked-section">
         <i class="fa fa-tag" aria-hidden="true"></i>
         &nbsp;{{- tag -}}&nbsp;({{site.tags[tag].size}})
     </h2>
     <div class="post-list">
-        {%- for post in site.tags[tag] -%}
+        {% for post in site.tags[tag] %}
             <div class="tag-entry">
                 <a href="{{- site.url -}}{{- post.url -}}">{{- post.title -}}</a>
                 <div class="entry-date">
                     <time datetime="{{- post.date | date_to_xmlschema -}}">{{- post.date | date: "%B %d, %Y" -}}</time>
                 </div>
             </div>
-        {%- endfor -%}
+        {% endfor %}
     </div>
-{%- endfor -%}
+{% endfor %}
 </div>


### PR DESCRIPTION
…map -> plugins_dir

Hello & Thanks a lot for the project, we're using it on [scapy](https://scapy.net/)

- Recent jekyll versions have stopped supporting the `{%-` format, and now require the `{%` format. While most of the code already has the new format, this PR cleans up the last bits.
- `jekyll-sitemap` is now required to go in `plugins_dir` rather than `plugins` (according to warnings when building)