### PR TITLE
Fixed avatar img link on LINE51 (contained space)

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -48,7 +48,7 @@
 	{% elsif site.avatar and (layout.show-avatar or page.show-avatar) %}
 	<div class="avatar-container">
 	  <div class="avatar-img-border">
-	    <a href="{{ site.url }} ">
+	    <a href="{{ site.url }}">
 	      <img class="avatar-img" src="{{ site.avatar | prepend: site.baseurl | replace: '//', '/' }}" />
 		</a>
 	  </div>


### PR DESCRIPTION
Removed the extra space after {{ site.url }} and before "
This prevents an error "This site can’t be reached" when clicking the Avatar to return home.

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
