### PR TITLE
German translation improvements

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -172,18 +172,18 @@ zh-HK:
 # German / Deutsch
 # ----------------
 de: &DEFAULT_DE
-  comments_label             : "Hinterlassen Sie einen Kommentar"
-  comments_title             : "Kommentare"
-  comment_form_info          : "Ihre E-Mail Adresse wird nicht veröffentlicht. Benötigte Felder sind markiert"
+  comments_label : "Hinterlasse einen Kommentar"
+  comments_title : "Kommentare"
+  comment_form_info : "Die E-Mail Adresse wird nicht veröffentlicht. Benötigte Felder sind markiert"
   comment_form_comment_label : "Kommentar"
-  comment_form_md_info       : "Markdown wird unterstützt."
-  comment_form_name_label    : "Name"
-  comment_form_email_label   : "E-Mail-Addresse"
+  comment_form_md_info : "Markdown wird unterstützt."
+  comment_form_name_label : "Name"
+  comment_form_email_label : "E-Mail-Adresse"
   comment_form_website_label : "Webseite (optional)"
-  comment_btn_submit         : "Kommentar absenden"
-  comment_btn_submitted      : "Versendet"
-  comment_success_msg        : "Danke für Ihren Kommentar! Er wird auf der Seite angezeigt, nachdem er geprüft wurde."
-  comment_error_msg          : "Entschuldigung, es gab einen Fehler. Bitte füllen Sie alle benötigten Felder aus und versuchen Sie es erneut."
+  comment_btn_submit : "Kommentar absenden"
+  comment_btn_submitted : "Versendet"
+  comment_success_msg : "Danke für den Kommentar! Er wird nach Prüfung auf der Seite angezeigt."
+  comment_error_msg : "Entschuldigung, es gab einen Fehler. Bitte fülle alle benötigten Felder aus und versuche es erneut."
 de-DE:
   <<: *DEFAULT_DE
 de-AT:


### PR DESCRIPTION
You did a amazing Job with this template. I really like it as base for my own project.
So I'd have one error and one request for improvement. All regarding the German translation in ui-text.yml.

[...]
comment_form_email_label : "E-Mail-Addresse"
[...]
There i one d too much. the word is 'E-Mail-Adresse'.

The 'Sie' is very formal. Meanwhile even in Germany is the 'you' well accepted. Especially online it is common to use the more casual 'Du'. But it is not an error, it is just my idea to improve the theme.
The Change is what I've changed for my site.

(See also https://github.com/daattali/beautiful-jekyll/issues/454)

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
