### PR TITLE
Add permission for jekyll user on Gemfile in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jekyll/jekyll
 
-COPY Gemfile .
-COPY Gemfile.lock .
+COPY --chown=jekyll:jekyll Gemfile .
+COPY --chown=jekyll:jekyll Gemfile.lock .
 
 RUN bundle install --quiet --clean
 


### PR DESCRIPTION
Patch for docker build error: 
```
There was an error while trying to write to /srv/jekyll/Gemfile.lock. 
It is likely that you need to grant write permissions for that path.
```