### PR TITLE
added ability to center images

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -103,6 +103,11 @@ img {
   margin-top: -25px;
 }
 
+.center-image
+{
+    margin: 0 auto;
+    display: block;
+}
 /* --- Navbar --- */
 
 .navbar-custom {


### PR DESCRIPTION
I added the ability to center images on pages and posts using markdown. I found it useful for one of my pages and thought others might think so too.

Apologies if you already had this functionality built-in, however, I could not find it in the markdown tutorial.

Can be performed by adding {: .center-image } at the end of an image line like so:
``` ![Image Name](/img/image-file.jpg){: .center-image } ```

Thanks again for putting beautiful jekyll together! I found it extremely useful and I am grateful for it. Hopefully you will find this small addition useful as well.