### PR TITLE
Staticman documentation enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To use Facebook comments, create a Facebook app using [Facebook developers](http
 
 To use Staticman, you first need to invite `staticmanlab` as a collaborator to your repository (by going to your repository **Settings** page, navigate to the **Collaborators** tab, and add the username `staticmanlab`), and then accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`. Lastly, fill in your `repository` and `branch` in the Staticman section of `_config.yml`.
 
-It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.  If you wish to keep reCAPTCHA disabled, to avoid getting a comment submission error, at the bottom of `staticman.yml`, please change `siteKey` and `secret` to the empty string, like `secret: ""`.
+Optional: It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.
 
 Optional: You might want to configure a webhook to prevent inactive branches representing merged comments from stacking up.  You may refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.  Please input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ To use Facebook comments, create a Facebook app using [Facebook developers](http
 
 To use Staticman, you first need to invite `staticmanlab` as a collaborator to your repository (by going to your repository **Settings** page, navigate to the **Collaborators** tab, and add the username `staticmanlab`), and then accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`. Lastly, fill in your `repository` and `branch` in the Staticman section of `_config.yml`.
 
+Notes: You may choose other Staticman API instance.  In this case, adjust the collaborator, the above invitation link and `endpoint` in the Staticman section of `_config.yml` accordingly.  In addition, the parameters `<username>` and `<repo-name>` are case-sensitive.
+
 Optional: It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.
 
 Optional: You might want to configure a webhook to prevent inactive branches representing merged comments from stacking up.  You may refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.  Please input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.

--- a/README.md
+++ b/README.md
@@ -116,13 +116,9 @@ To use Facebook comments, create a Facebook app using [Facebook developers](http
 
 #### Staticman comments
 
-To use Staticman, you first need to invite `staticmanlab` as a collaborator to your repository (by going to your repository **Settings** page, navigate to the **Collaborators** tab, and add the username `staticmanlab`), and then accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`. Lastly, fill in your `repository` and `branch` in the Staticman section of `_config.yml`.
+To use Staticman, you first need to invite `staticmanlab` as a collaborator to your repository (by going to your repository **Settings** page, navigate to the **Collaborators** tab, and add the username `staticmanlab`), and then accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`. Lastly, fill in the `staticman` parameters in the Staticman section of `_config.yml`. You may also choose a different Staticman instance other than `staticmanlab`.
 
-Notes: You may choose other Staticman API instance.  In this case, adjust the collaborator, the above invitation link and `endpoint` in the Staticman section of `_config.yml` accordingly.  In addition, the parameters `<username>` and `<repo-name>` are case-sensitive.
-
-Optional: It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.
-
-Optional: You might want to configure a webhook to prevent inactive branches representing merged comments from stacking up.  You may refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.  Please input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
+Optional: You may want to configure a webhook to prevent old inactive branches (representing approved comments) from stacking up.  You can refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.  Make sure to input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
 
 #### JustComments
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ To use Facebook comments, create a Facebook app using [Facebook developers](http
 
 To use Staticman, you first need to invite `staticmanlab` as a collaborator to your repository (by going to your repository **Settings** page, navigate to the **Collaborators** tab, and add the username `staticmanlab`), and then accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`. Lastly, fill in your `repository` and `branch` in the Staticman section of `_config.yml`.
 
-Optional: It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.
+It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.  If you wish to keep reCAPTCHA disabled, to avoid getting a comment submission error, at the bottom of `staticman.yml`, please change `siteKey` and `secret` to the empty string, like `secret: ""`.
 
-Optional: You might want to configure a webhook to prevent inactive branches representing merged comments from stacking up.  You may refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.
+Optional: You might want to configure a webhook to prevent inactive branches representing merged comments from stacking up.  You may refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.  Please input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
 
 #### JustComments
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ To use Staticman, you first need to invite `staticmanlab` as a collaborator to y
 
 Optional: It is suggested to enable reCAPTCHA to avoid massive spam comments.  You may refer to `_config.yml` for detailed instructions.
 
+Optional: You might want to configure a webhook to prevent inactive branches representing merged comments from stacking up.  You may refer to [Staticman's documenation](https://staticman.net/docs/webhooks) for details.
+
 #### JustComments
 
 To use JustComments you first need to have an account. After you just need to copy the API key to the `just-comments` property in `_config.yml` file.

--- a/_config.yml
+++ b/_config.yml
@@ -126,11 +126,11 @@ url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 # To use Facebook Comments, fill in a Facebook App ID
 # fb_comment_id: ""
 
-# Staticman support (parameters under this section are CASE-sensitive)
+# To use Staticman comments, fill in repository, branch, and endpoint
 staticman:
   repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
-  branch     : # eg. "master" If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-  endpoint   : # URL of your own deployment (with trailing slash) (will fallback to a public GitLab instance) eg. https://<your-api>/v3/entry/github/
+  branch     : master # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
+  endpoint   : # URL of your own deployment, with a trailing slash (will fallback to a public GitLab instance) eg. https://<your-api>/v3/entry/github/
   reCaptcha:
     # reCaptcha for Staticman (OPTIONAL, but recommended for spam protection)
     # If you use reCaptcha, you must also set these parameters in staticman.yml

--- a/_config.yml
+++ b/_config.yml
@@ -130,9 +130,9 @@ url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 staticman:
   repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
   branch     : # eg. "master" If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-  endpoint   : # URL of your own deployment (with trailing slash) (will fallback to a public GitLab instance)
+  endpoint   : # URL of your own deployment (with trailing slash) (will fallback to a public GitLab instance) eg. https://<your-api>/v3/entry/github/
   reCaptcha:
-    # reCaptcha for Staticman (OPTIONAL)
+    # reCaptcha for Staticman (OPTIONAL, but recommended for spam protection)
     # If you use reCaptcha, you must also set these parameters in staticman.yml
     siteKey  : # Use your own site key, you need to apply for one on Google
     secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>

--- a/_config.yml
+++ b/_config.yml
@@ -126,7 +126,7 @@ url-pretty: "MyWebsite.com"  # eg. "deanattali.com/beautiful-jekyll"
 # To use Facebook Comments, fill in a Facebook App ID
 # fb_comment_id: ""
 
-# Staticman support
+# Staticman support (parameters under this section are CASE-sensitive)
 staticman:
   repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
   branch     : # eg. "master" If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`

--- a/staticman.yml
+++ b/staticman.yml
@@ -101,8 +101,8 @@ comments:
   # Use your OWN siteKey and secret.
   reCaptcha:
     enabled: false
-    # siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
+    #siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
     # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
     # i.e. https://staticman3.herokuapp.com/v3/encrypt/{your-site-secret}
     # For more information, https://staticman.net/docs/encryption
-    # secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="
+    #secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="

--- a/staticman.yml
+++ b/staticman.yml
@@ -98,11 +98,11 @@ comments:
 
   # reCAPTCHA (OPTIONAL)
   # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
-  # Either use your OWN siteKey and secret, or change them to the empty string "".
+  # Use your OWN siteKey and secret.
   reCaptcha:
     enabled: false
-    siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
+    # siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
     # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
     # i.e. https://staticman3.herokuapp.com/v3/encrypt/{your-site-secret}
     # For more information, https://staticman.net/docs/encryption
-    secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="
+    # secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="

--- a/staticman.yml
+++ b/staticman.yml
@@ -4,7 +4,8 @@
 # another one to handle posts.
 # To encrypt strings use the following endpoint:
 # https://{STATICMAN API INSTANCE}/v3/encrypt/{TEXT TO BE ENCRYPTED}
-# {STATICMAN API INSTANCE} defaults to staticman3.herokuapp.com
+# {STATICMAN API INSTANCE} should match the `endpoint` in the theme config
+# file. It defaults to "staticman3.herokuapp.com".
 
 comments:
   # (*) REQUIRED
@@ -22,8 +23,8 @@ comments:
 
   # (*) REQUIRED
   #
-  # Name of the branch being used. Must match the one sent in the URL of the
-  # request.
+  # Name of the branch being used. Must match the `branch` in the theme config
+  # file.
   branch: "master"   #  use "master" for user page
   #branch: "gh-pages" #  use "gh-pages" for project page
 
@@ -98,11 +99,12 @@ comments:
 
   # reCAPTCHA (OPTIONAL)
   # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
-  # Use your OWN siteKey and secret.
+  # To enable reCAPTCHA, set `enabled` to "true", and uncomment `siteKey` and `secret`
+  # below, and use your OWN ones.
   reCaptcha:
     enabled: false
     #siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
     # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
-    # i.e. https://staticman3.herokuapp.com/v3/encrypt/{your-site-secret}
+    # i.e. https://{STATICMAN API INSTANCE}/v3/encrypt/{your-site-secret}
     # For more information, https://staticman.net/docs/encryption
     #secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="

--- a/staticman.yml
+++ b/staticman.yml
@@ -98,7 +98,7 @@ comments:
 
   # reCAPTCHA (OPTIONAL)
   # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
-  # Use your OWN siteKey and secret.
+  # Either use your OWN siteKey and secret, or change them to the empty string "".
   reCaptcha:
     enabled: false
     siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"

--- a/staticman.yml
+++ b/staticman.yml
@@ -25,8 +25,7 @@ comments:
   #
   # Name of the branch being used. Must match the `branch` in the theme config
   # file.
-  branch: "master"   #  use "master" for user page
-  #branch: "gh-pages" #  use "gh-pages" for project page
+  branch: "master"   #  use "master" for user page or "gh-pages" for project pages
 
   commitMessage: "New comment by {fields.name}"
 
@@ -98,13 +97,14 @@ comments:
     email: md5
 
   # reCAPTCHA (OPTIONAL)
-  # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
-  # To enable reCAPTCHA, set `enabled` to "true", and uncomment `siteKey` and `secret`
-  # below, and use your OWN ones.
+  # To enable reCAPTCHA:
+  # 1. Set `enabled` to `true`
+  # 2. Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
+  # 3. Uncomment `siteKey` and `secret` and fill them in with your values
   reCaptcha:
     enabled: false
-    #siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
-    # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
+    #siteKey: ""
+    # ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
     # i.e. https://{STATICMAN API INSTANCE}/v3/encrypt/{your-site-secret}
-    # For more information, https://staticman.net/docs/encryption
-    #secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="
+    # For more information, visit https://staticman.net/docs/encryption
+    #secret: ""


### PR DESCRIPTION
# Webhook configuration

When `moderation: true` in `staticman.yml`, a PR containing a branch like `staticman_5525bf80-055f-11e9-a156-295f601b09e8` is created.  After merging such PR, such branch would become useless.  We have better offer an advice for automatic deletion after merging to avoid such branches from piling up.

The technical details consist of several steps.  I redirect interested users to the [relevant page in the official doc](https://staticman.net/docs/webhooks), and adding necessary adaptations.

# Changes in the comments in site config file
## A sample Staticman API endpoint

The current `endpoint` parameter is borrowed from `_includes/comments.html` in https://github.com/mmistakes/minimal-mistakes/pull/1845.  Due to [Staticman's URL scheme change introduced in v3](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#staticman-v3), one has to add an extra parameter `service` which accepts either `github` or `gitlab` in the `<form action="url">`.  Unluckily, this has _not_ yet been documented in Staticman's official site.  As a result, some users are _not_ aware of such change, and spend time on fruitless try-and-error.  Different blog themes might have different logic to complete the `form action` URL.  For instance, in [Hugo Swift Theme](https://github.com/onweru/hugo-swift-theme#staticman-comments), in which I have been invited to collaborate, there's a `gitProvider` parameter.  Nonetheless, I've _no_ intention to change the template code in #440 to keep things working.  According to Staticman's author's comment in https://github.com/eduardoboucas/staticman/issues/264#issuecomment-460446511, Staticman's job is to get the HTML form data into the GitHub/GitLab repo, so the only appropriate place to document such theme-specific logic is the theme's README and relevant config files.

## Little complement of #509 

Sometimes, users might not read all of the section **Staticman comments** in the README.  Therefore, a short reminder in the comments might catch them.

# Updates in the comments in the repo config file

## Background [TL;DR]

I received a 500 error during comment submission to the public API instance for Framagit (i.e. https://staticman-frama.herokuapp.com/) in a private clone of this repo.  From the "server side", I know that I've got the correct API config parameters.  It took me hours of experiments to [rediscover the cause  of such 500 error](https://vincenttam.gitlab.io/post/2018-12-25-staticman-repo-setup-errors/): at the bottom of `staticman.yml`, under the section `reCAPTCHA`, I've kept the default `enabled: false` for convenience, but I left `secret` unchanged while changing the `endpoint` in `_config.yml`.  That reCAPTCHA `secret` was encrypted with this theme's default API instance (i.e. https://staticman3.herokuapp.com/), while the `endpoint` is holding _another_ private RSA key.  That would trigger a 500 error from the API server with a short and unhelpful response `{success: false}`.

## Steps for reproducing a 500 error under this theme

1. In `config.yml`: enable Staticman and change `endpoint` to *another* API instance.
2. Keep reCAPTCHA settings at the bottom of `staticman.yml` (i.e. reCAPTCHA disabled, but with non-empty `siteKey` and `secret`.)

Since the `endpoint` is changed, the corresponding RSA private key no longer matches the one used for encrypting reCAPTCHA `secret` in the `master` branch.  That would cause a 500 error from the API server, even if `enabled` is set to `false`, and reCAPTCHA parameters are empty in `_config.yml`.

## Proposed solutions
Either one will do.  @daattali please let me know which one you prefer.  The README might need further editing before it can get merged.
### Keep the reCAPTCHA section uncommented
In this case, no matter the user use reCAPTCHA or not, (s)he has to modify the repo config.

- enable reCAPTCHA: supply own `siteKey` and `secret`
- disable reCAPTCHA: change the values to `siteKey: ""` and `secret: ""`

I've written README based on this solution, but after creating this PR, I've found another simpler approach.

```yml
  # reCAPTCHA (OPTIONAL)
  # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
  # Either use your OWN siteKey and secret, or change them to the empty string "".
  reCaptcha:
    enabled: false
    siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
    # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
    # i.e. https://staticman3.herokuapp.com/v3/encrypt/{your-site-secret}
    # For more information, https://staticman.net/docs/encryption
    secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="
```

### Comment out the whole reCAPTCHA section

- reCAPTCHA users can simply uncomment the parameters to get things work.
- Otherwise, one can simply leave this untouched.

I personally prefer this approach.  First, this is in line with the convention of switching off everything in this repo.  Second, this requires less editing for non reCAPTCHA users.  The only marginal drawback of this approach would be the additional difficulty to distinguish parameters from comments in the commented code below, but that shouldn't be an issue for normal users who know basic YML.  If you prefer this approach, please let me know, so that I'll edit the README accordingly.

```yml
  # reCAPTCHA (OPTIONAL)
  # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
  # Either use your OWN siteKey and secret, or change them to the empty string "".
  # reCaptcha:
    # enabled: false
    # siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
    # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
    # i.e. https://staticman3.herokuapp.com/v3/encrypt/{your-site-secret}
    # For more information, https://staticman.net/docs/encryption
    # secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="
```