### PR TITLE
Fix JavaScript loading order

### DIFF
--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -4,18 +4,6 @@
   {% endfor %}
 {% endif %}
 
-{% if page.ext-js %}
-  {% for js in page.ext-js %}
-    {% include ext-js.html js=js %}
-  {% endfor %}
-{% endif %}
-
-{% if page.js %}
-  {% for js in page.js %}
-    <script src="{{ js | relative_url }}"></script>
-  {% endfor %}
-{% endif %}
-
 {% if layout.common-js %}
   {% for js in layout.common-js %}
     <!-- doing something a bit funky here because I want to be careful not to include JQuery twice! -->
@@ -28,5 +16,17 @@
     {% else %}
       <script src="{{ js | relative_url }}"></script>
     {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% if page.ext-js %}
+  {% for js in page.ext-js %}
+    {% include ext-js.html js=js %}
+  {% endfor %}
+{% endif %}
+
+{% if page.js %}
+  {% for js in page.js %}
+    <script src="{{ js | relative_url }}"></script>
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
Fixes #342

This request simply changes the order scripts are loaded in footer-scripts.html, which addresses an issue where jquery and boostrap are undefined in page scripts.

The loading order proposed is **common-ext-js -> common-js -> ext-js -> page-js** because common scripts should be loaded before page scripts, and external scripts should be loaded before local scripts for the same reason, which is that local scripts may want to reference APIs from external sources.