### PR TITLE
Style fixes to help keyboard navigation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -230,14 +230,13 @@ img {
   border-width: 0 1px 1px 1px;
   font-weight: normal;
 }
-@media only screen and (max-width: 767px) {
-  .navbar-custom .nav .navlinks-container.show-children {
-    background: rgba(0, 0, 0, 0.2);
-  }
-  .navbar-custom .nav .navlinks-container.show-children .navlinks-children {
-    display: block;
-  }
+.navbar-custom .nav .navlinks-container.show-children {
+  background: rgba(0, 0, 0, 0.2);
 }
+.navbar-custom .nav .navlinks-container.show-children .navlinks-children {
+  display: block;
+}
+
 @media only screen and (min-width: 768px) {
   .navbar-custom .nav .navlinks-container {
     text-align: center;
@@ -757,6 +756,8 @@ pre {
 .navbar-default button.navbar-toggle:focus,
 .navbar-default button.navbar-toggle:hover {
   background-color: initial;
+  outline: 1px dotted #212121;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .navbar-default button.navbar-toggle[aria-expanded="true"] {

--- a/js/main.js
+++ b/js/main.js
@@ -25,7 +25,7 @@ var main = {
       $(".navbar").removeClass("top-nav-expanded");
     });
 
-    // On mobile, when clicking on a multi-level navbar menu, show the child links
+    // When clicking or hitting enter on a multi-level navbar menu, show the child links
     $('#main-navbar').on("click", ".navlinks-parent", function(e) {
       var target = e.target;
       $.each($(".navlinks-parent"), function(key, value) {


### PR DESCRIPTION
Hello! Thank you for making such a nice free theme available. I noticed there were a couple of small fixes I could make to improve accessibility and [keyboard navigation](https://webaim.org/techniques/keyboard/). My proposed changes:

- Re-add default focus styling to the navbar toggle button so keyboard users can see when they've tabbed to the menu button on smaller screens.  It looks like bootstrap.min.css had disabled it with `outline:0`. 
- Move CSS for showing nav link children out of a media query so that it affects desktop nav links as well. This is because when I tabbed to the dropdown nav link, I couldn't open the drop down by hitting the enter key. 
- Update JS comment to reflect new behavior.

Thanks again and looking forward to your thoughts on this!