### PR TITLE
Fix footer does not stick to the bottom

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,13 +20,13 @@ common-js:
   {% include head.html %}
 
   <body>
-
+    <div class="content">
     {% include gtm_body.html %}
   
     {% include nav.html %}
 
     {{ content }}
-
+    </div>  
     {% include footer.html %}
   
     {% include footer-scripts.html %}

--- a/css/main.css
+++ b/css/main.css
@@ -6,8 +6,13 @@ layout: null
 
 /* --- General --- */
 
+html, body {
+  height: 100%;
+}
 body {
   font-family: 'Lora', 'Times New Roman', serif;
+  display: flex;
+  flex-direction: column;
   font-size: 18px;
   color: #404040;
   position: relative;
@@ -63,6 +68,10 @@ hr.small {
 
 .hideme {
   display: none;
+}
+
+.content {
+  flex: 1 0 auto;
 }
 
 ::-moz-selection {
@@ -261,6 +270,7 @@ img {
 /* --- Footer --- */
 
 footer {
+  flex-shrink: 0;
   padding: 30px 0;
   border-top: 1px #EAEAEA solid;
   margin-top: 50px;


### PR DESCRIPTION
## Resolves #576 

This PR does not affect the current behavior of the footer except for the edge case described in the issue: when there is a small content or none the footer now stays at the bottom the page.

Because the height of the footer can change, most of the solutions around didn't work. Using `flexbox` for a sticky footer not only doesn't require any extra elements, but allows for a variable height footer.
