### PR TITLE
Update to Font Awesome 5

### DIFF
--- a/_data/SocialNetworks.yml
+++ b/_data/SocialNetworks.yml
@@ -4,88 +4,89 @@
 #   name: Specify a user-friendly name that will be used as a link title
 #   urlTemplate: Define a URL template. The variable {value} will be replaced
 #                with the value of site.social-network-links.<key>
-#   icon: Specify a valid fontawesome icon class
+#   icon: Specify valid fontawesome icon classes (style + icon),
+#         e.g. "fab fa-github" or "fas fa-rss"
 
 facebook:
   name: "Facebook"
   urlTemplate: "https://www.facebook.com/{value}"
-  icon: "fa-facebook"
+  icon: "fab fa-facebook"
 
 github:
   name: "GitHub"
   urlTemplate: "https://github.com/{value}"
-  icon: "fa-github"
+  icon: "fab fa-github"
 
 twitter:
   name: "Twitter"
   urlTemplate: "https://twitter.com/{value}"
-  icon: "fa-twitter"
+  icon: "fab fa-twitter"
 
 reddit:
   name: "Reddit"
   urlTemplate: "https://reddit.com/u/{value}"
-  icon: "fa-reddit"
+  icon: "fab fa-reddit"
 
 email:
   name: "Email me"
   urlTemplate: "mailto:{value}"
-  icon: "fa-envelope"
+  icon: "fas fa-envelope"
 
 linkedin:
   name: "LinkedIn"
   urlTemplate: "https://linkedin.com/in/{value}"
-  icon: "fa-linkedin"
+  icon: "fab fa-linkedin"
 
 xing:
   name: "Xing"
   urlTemplate: "https://www.xing.com/profile/{value}"
-  icon: "fa-xing"
+  icon: "fab fa-xing"
 
 stackoverflow:
   name: "StackOverflow"
   urlTemplate: "https://stackoverflow.com/users/{value}"
-  icon: "fa-stack-overflow"
+  icon: "fab fa-stack-overflow"
 
 snapchat:
   name: "Snapchat"
   urlTemplate: "https://www.snapchat.com/add/{value}"
-  icon: "fa-snapchat-ghost"
+  icon: "fab fa-snapchat-ghost"
 
 instagram:
   name: "Instagram"
   urlTemplate: "https://www.instagram.com/{value}"
-  icon: "fa-instagram"
+  icon: "fab fa-instagram"
 
 youtube:
   name: "YouTube"
   urlTemplate: "https://www.youtube.com/{value}"
-  icon: "fa-youtube"
+  icon: "fab fa-youtube"
 
 spotify:
   name: "Spotify"
   urlTemplate: "https://open.spotify.com/user/{value}"
-  icon: "fa-spotify"
+  icon: "fab fa-spotify"
 
 telephone:
   name: "Phone"
   urlTemplate: "tel:{value}"
-  icon: "fa-phone"
+  icon: "fas fa-phone"
 
 rss:
   name: "RSS"
-  icon: "fa-rss"
+  icon: "fas fa-rss"
 
 steam:
   name: "Steam"
   urlTemplate: "https://steamcommunity.com/id/{value}"
-  icon: "fa-steam"
+  icon: "fab fa-steam"
 
 twitch:
   name: "Twitch"
   urlTemplate: "https://www.twitch.tv/{value}"
-  icon: "fa-twitch"
+  icon: "fab fa-twitch"
 
 yelp:
   name: "Yelp"
   urlTemplate: "https://{value}.yelp.com"
-  icon: "fa-yelp"
+  icon: "fab fa-yelp"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,8 +16,8 @@
             <li>
               <a href="{{ url }}" title="{{ element.name }}">
                 <span class="fa-stack fa-lg" aria-hidden="true">
-                  <i class="fa fa-circle fa-stack-2x"></i>
-                  <i class="fa {{ element.icon }} fa-stack-1x fa-inverse"></i>
+                  <i class="fas fa-circle fa-stack-2x"></i>
+                  <i class="{{ element.icon }} fa-stack-1x fa-inverse"></i>
                 </span>
                 <span class="sr-only">{{ element.name }}</span>
               </a>

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -14,7 +14,7 @@
   <!--- Share on Twitter -->
     <a href="https://twitter.com/intent/tweet?text={{ page.title | url_encode }}&url={{ page.url | absolute_url | url_encode }}"
       class="btn btn-social-icon btn-twitter" title="Share on Twitter">
-      <span class="fa fa-fw fa-twitter" aria-hidden="true"></span>
+      <span class="fab fa-fw fa-twitter" aria-hidden="true"></span>
       <span class="sr-only">Twitter</span>
     </a>
   {% endif %}
@@ -23,7 +23,7 @@
   <!--- Share on Facebook -->
     <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}"
       class="btn btn-social-icon btn-facebook" title="Share on Facebook">
-      <span class="fa fa-fw fa-facebook" aria-hidden="true"></span>
+      <span class="fab fa-fw fa-facebook" aria-hidden="true"></span>
       <span class="sr-only">Facebook</span>
     </a>
   {% endif %}
@@ -32,7 +32,7 @@
   <!--- Share on LinkedIn -->
     <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}"
       class="btn btn-social-icon btn-linkedin" title="Share on LinkedIn">
-      <span class="fa fa-fw fa-linkedin" aria-hidden="true"></span>
+      <span class="fab fa-fw fa-linkedin" aria-hidden="true"></span>
       <span class="sr-only">LinkedIn</span>
     </a>
   {% endif %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,7 +4,7 @@ common-css:
   - "/css/bootstrap-social.css"
   - "/css/main.css"
 common-ext-css:
-  - "//maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css"
+  - "//cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
 common-googlefonts:
   - "Lora:400,700,400italic,700italic"
   - "Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"

--- a/tags.html
+++ b/tags.html
@@ -11,13 +11,13 @@ title: 'Tag Index'
 {%- assign tags_list = site_tags | split:',' | sort -%}
 
 {%- for tag in tags_list -%}
-    <a href="#{{- tag -}}" class="btn btn-primary tag-btn"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{- tag -}}&nbsp;({{site.tags[tag].size}})</a>
+    <a href="#{{- tag -}}" class="btn btn-primary tag-btn"><i class="fas fa-tag" aria-hidden="true"></i>&nbsp;{{- tag -}}&nbsp;({{site.tags[tag].size}})</a>
 {%- endfor -%}
 
 <div id="full-tags-list">
 {%- for tag in tags_list -%}
     <h2 id="{{- tag -}}" class="linked-section">
-        <i class="fa fa-tag" aria-hidden="true"></i>
+        <i class="fas fa-tag" aria-hidden="true"></i>
         &nbsp;{{- tag -}}&nbsp;({{site.tags[tag].size}})
     </h2>
     <div class="post-list">


### PR DESCRIPTION
- uses the CSS version
- updates `_data/SocialNetworks.yml` to make the icon property include both the Font Awesome style class and the icon class, e.g. `fab fa-github`
- updates all static usages to use the new CSS classes for the Font Awesome style (`fas` = solid, `fab` = brands)
- the new version doesn't seem to be available on `maxcdn.bootstrapcdn.com`, so I used `cdnjs.cloudflare.com`; see https://cdnjs.com/about 