### PR TITLE
add new comments - gitalk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ To use Staticman, you first need to invite `staticmanlab` as a collaborator to y
 
 Optional: You may want to configure a webhook to prevent old inactive branches (representing approved comments) from stacking up.  You can refer to [Staticman's documentation](https://staticman.net/docs/webhooks) for details.  Make sure to input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
 
-#### Gittalk comments 
-To use gittalk, you first need to register a gitHub application by going to register github application (https://github.com/settings/applications/new), **Note** You must specify the website domain url in the Authorization callback URL field.  Lastly, fill in the github application's `Client ID`、`Client Secret` and `gittalk` parameters in the Gittalk section of `_config.yml`.
+#### Gitalk comments 
+To use gitalk, you first need to register a gitHub application by going to register github application (https://github.com/settings/applications/new), **Note** You must specify the website domain url in the Authorization callback URL field.  Lastly, fill in the github application's `Client ID`、`Client Secret` and `gitalk` parameters in the Gittalk section of `_config.yml`.
 
 ### Adding Google Analytics to track page views
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ To use Staticman, you first need to invite `staticmanlab` as a collaborator to y
 
 Optional: You may want to configure a webhook to prevent old inactive branches (representing approved comments) from stacking up.  You can refer to [Staticman's documentation](https://staticman.net/docs/webhooks) for details.  Make sure to input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
 
+#### Gittalk comments 
+To use gittalk, you first need to register a gitHub application by going to register github application (https://github.com/settings/applications/new), **Note** You must specify the website domain url in the Authorization callback URL field.  Lastly, fill in the github application's `Client ID`、`Client Secret` and `gittalk` parameters in the Gittalk section of `_config.yml`.
+
 ### Adding Google Analytics to track page views
 
 Beautiful Jekyll lets you easily add Google Analytics to all your pages. This will let you track all sorts of information about visits to your website, such as how many times each page is viewed and where (geographically) your users come from.  To add Google Analytics, simply sign up to [Google Analytics](https://www.google.com/analytics/) to obtain your Google Tracking ID, and add this tracking ID to the `google_analytics` parameter in `_config.yml`.

--- a/_config.yml
+++ b/_config.yml
@@ -135,12 +135,12 @@ staticman:
     secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
 # To use Gittalk comments  https://github.com/gitalk/gitalk#Usage  fill in clientID, clientSecret, repository, owner and admin
-gittalk:
+gitalk:
   # Note: A GitHub Application is needed for authorization, if you don't have one, going to https://github.com/settings/applications/new register a new one.
   # You must specify the website domain url in the Authorization callback URL field.
   clientID:  # GitHub Application Client ID
   clientSecret:   # GitHub Application Client Secret,
-  repository:   # Storage gittalk's repository eg. blog-comments
+  repository:   # Storage gitalk's repository eg. blog-comments
   owner:   # GitHub repo owner,
   admin:   # GitHub repo owner and collaborators, only these guys can initialize github issues eg. 'colynn,daattali'
 

--- a/_config.yml
+++ b/_config.yml
@@ -134,6 +134,16 @@ staticman:
     siteKey  : # Use your own site key, you need to apply for one on Google
     secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
+# To use Gittalk comments  https://github.com/gitalk/gitalk#Usage  fill in clientID, clientSecret, repository, owner and admin
+gittalk:
+  # Note: A GitHub Application is needed for authorization, if you don't have one, going to https://github.com/settings/applications/new register a new one.
+  # You must specify the website domain url in the Authorization callback URL field.
+  clientID:  # GitHub Application Client ID
+  clientSecret:   # GitHub Application Client Secret,
+  repository:   # Storage gittalk's repository eg. blog-comments
+  owner:   # GitHub repo owner,
+  admin:   # GitHub repo owner and collaborators, only these guys can initialize github issues eg. 'colynn,daattali'
+
 # --- Misc --- #
 
 # Facebook App ID

--- a/_includes/gitalk-comment.html
+++ b/_includes/gitalk-comment.html
@@ -1,14 +1,14 @@
-{% if site.gittalk.clientID and site.gittalk.clientSecret %}
+{% if site.gitalk.clientID and site.gitalk.clientSecret %}
 <div id="gitalk-container"></div>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
 <script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
 <script >
   const gitalk = new Gitalk({
-    clientID: '{{ site.gittalk.clientID }}',
-    clientSecret: "{{ site.gittalk.clientSecret }}",
-    repo: "{{ site.gittalk.repository }}",
-    owner: "{{ site.gittalk.owner }}",
-    admin: ["{{ site.gittalk.admin | split: ','  | join: '","'}}"],
+    clientID: '{{ site.gitalk.clientID }}',
+    clientSecret: "{{ site.gitalk.clientSecret }}",
+    repo: "{{ site.gitalk.repository }}",
+    owner: "{{ site.gitalk.owner }}",
+    admin: ["{{ site.gitalk.admin | split: ','  | join: '","'}}"],
     id: "{{ page.url }}",    // Ensure uniqueness and length less than 50 
     distractionFreeMode: false,  // Facebook-like distraction free mode
     perPage: 100

--- a/_includes/gittalk-comment.html
+++ b/_includes/gittalk-comment.html
@@ -1,0 +1,20 @@
+{% if site.gittalk.clientID and site.gittalk.clientSecret %}
+<div id="gitalk-container"></div>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
+<script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
+<script >
+  const gitalk = new Gitalk({
+    clientID: '{{ site.gittalk.clientID }}',
+    clientSecret: "{{ site.gittalk.clientSecret }}",
+    repo: "{{ site.gittalk.repository }}",
+    owner: "{{ site.gittalk.owner }}",
+    admin: ["{{ site.gittalk.admin | split: ','  | join: '","'}}"],
+    id: "{{ page.url }}",    // Ensure uniqueness and length less than 50 
+    distractionFreeMode: false,  // Facebook-like distraction free mode
+    perPage: 100
+});
+
+gitalk.render('gitalk-container')
+</script>
+
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,6 +16,7 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
+	{% include gittalk-comment.html %}    
 	    {% endif %}
     </div>
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,7 +16,7 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
-	{% include gittalk-comment.html %}    
+	{% include gitalk-comment.html %}    
 	    {% endif %}
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -73,6 +73,7 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
+        {% include gittalk-comment.html %}
       {% endif %}
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -73,7 +73,7 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
-        {% include gittalk-comment.html %}
+        {% include gitalk-comment.html %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Background
For some reason, we can't use `disqus`/`staticman` as a comment tool very well, but all we have github account, and I find Gittalk[Gitalk is a modern comment component based on Github Issue and Preact](https://gitalk.github.io),  so I want to share it with us.

## Changes

1.  add `gittalk-comment.html` into `_includes`
2. change post.html/ page.html link to gittalk-comment.html
3. add Gittalk parameters into `_config.yml`  and `README.md` docs


## Demo
> If you page enable `comments` and setup Gittalk parameters correctly，you will see something like that
<img width="357" alt="gittalk" src="https://user-images.githubusercontent.com/5203608/77501417-f6049f00-6e92-11ea-8d56-5823ef6c937f.png">




