### PR TITLE
Add readtime

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -151,7 +151,7 @@ title-separator: "-"
 date_format: "%B %-d, %Y"
 
 # Read Time Option
-readtime: true # Change to true to include estimated reading time on posts
+read-time: true # Change to true to include estimated reading time on posts
 
 # --- Don't need to touch anything below here (but you can if you want) --- #
 

--- a/_config.yml
+++ b/_config.yml
@@ -150,9 +150,6 @@ title-separator: "-"
 # Ruby Date Format
 date_format: "%B %-d, %Y"
 
-# Read Time Option
-read-time: true # Change to true to include estimated reading time on posts
-
 # --- Don't need to touch anything below here (but you can if you want) --- #
 
 # Output options (more information on Jekyll's site)
@@ -175,6 +172,7 @@ defaults:
       layout: "post"
       comments: true  # add comments to all blog posts
       social-share: true # add social media sharing buttons to all blog posts
+      readtime: true # add estimated reading-time to all blog_posts
   -
     scope:
       path: "" # all files

--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,9 @@ title-separator: "-"
 # Ruby Date Format
 date_format: "%B %-d, %Y"
 
+# Read Time Option
+readtime: false # Change to true to include estimated reading time on posts
+
 # --- Don't need to touch anything below here (but you can if you want) --- #
 
 # Output options (more information on Jekyll's site)

--- a/_config.yml
+++ b/_config.yml
@@ -151,7 +151,7 @@ title-separator: "-"
 date_format: "%B %-d, %Y"
 
 # Read Time Option
-readtime: false # Change to true to include estimated reading time on posts
+readtime: true # Change to true to include estimated reading time on posts
 
 # --- Don't need to touch anything below here (but you can if you want) --- #
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,7 +36,7 @@
 		  {% endif %}
 		  
 		  {% if include.type == "post" %}
-		  <span class="post-meta">Posted on {{ page.date | date: site.date_format }}</span>
+		  <span class="post-meta">Posted on {{ page.date | date: site.date_format }}{% if site.readtime %}{% include readtime.html %}{% endif %}</span>
 		  {% endif %}
         </div>
       </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -61,7 +61,7 @@
 		  {% endif %}
 		  
 		  {% if include.type == "post" %}
-		  <span class="post-meta">Posted on {{ page.date | date: site.date_format }}</span>
+		  <span class="post-meta">Posted on {{ page.date | date: site.date_format }}{% if site.readtime %}{% include readtime.html %}{% endif %}</span>
 		  {% endif %}
         </div>
       </div>

--- a/_includes/readtime.html
+++ b/_includes/readtime.html
@@ -1,0 +1,27 @@
+<!--
+# "ReadTime on GitHub Jekyll"
+# (c) 2020 Ruby Griffith Ramirez, MIT License
+#
+# Outputs an estimated reading time for content based on a WPM division calculation.
+# The rough WPM figure used here can be changed after the "divided_by:" liquid filter.
+# Others rely on a higher value (e.g. 265 WPM for Medium.com) to account for images and so forth.
+# 
+# Usage: {% include readtime.html %} with readtime.html created within _includes folder.
+# Will emit an integer with "minute read" appended to it or with "< 1 minute read" replacing it.
+# For nil, a blank space takes its place. Replace blank with any other desired text.
+-->
+
+{% assign ReadTime = page.content | strip_html | number_of_words %}
+{% assign calcReadTime = ReadTime | float %}
+{% assign finalReadTime = calcReadTime | divided_by:250 | round: 2 %}
+{% assign number = finalReadTime | round %}
+  {% if number >= 1 %}
+    {% assign yesReadTime = number | append: " minute read" %}
+      {{ yesReadTime }}
+  {% elsif number < 1 %}
+    {% assign minReadTime = '&lt; 1 minute read' %}
+      {{ minReadTime }}
+  {% else %}
+    {% assign nilReadTime = number | replace:'0',' ' %}
+      {{ nilReadTime }}
+  {% endif %}

--- a/_includes/readtime.html
+++ b/_includes/readtime.html
@@ -17,10 +17,10 @@
 {% assign number = finalReadTime | round %}
   {% if number >= 1 %}
     {% assign yesReadTime = number | append: " minute read" %}
-      {{ yesReadTime }}
+      {{ yesReadTime | prepend: " &middot; " }}
   {% elsif number < 1 %}
     {% assign minReadTime = '&lt; 1 minute read' %}
-      {{ minReadTime }}
+      {{ minReadTime | prepend: " &middot; " }}
   {% else %}
     {% assign nilReadTime = number | replace:'0',' ' %}
       {{ nilReadTime }}


### PR DESCRIPTION
Feature suggestion - "How to display the time of reading on the blog #593"

This file makes it possible to use {% include readtime.html %} wherever an estimated read time is desired (such as next to post date).