### PR TITLE
add utterances comments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ To use Staticman, you first need to invite `staticmanlab` as a collaborator to y
 
 Optional: You may want to configure a webhook to prevent old inactive branches (representing approved comments) from stacking up.  You can refer to [Staticman's documentation](https://staticman.net/docs/webhooks) for details.  Make sure to input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
 
+
+### Utterances comments - gitlab issuse
+
+To use utterances(https://github.com/utterance/utterances), you first need prepare a public repo(already existing or create a new) to store comments, and then make sure the [utterances app](https://github.com/apps/utterances) is installed on the repo, otherwise users will not be able to post comments. **Note** If your repo is a fork, navigate to it's settings tab and confirm the issues feature is turned on.  Lastly, fill in the `uttenance` parameters in the Utterances section of `_config.yml`.
+
+
 ### Adding Google Analytics to track page views
 
 Beautiful Jekyll lets you easily add Google Analytics to all your pages. This will let you track all sorts of information about visits to your website, such as how many times each page is viewed and where (geographically) your users come from.  To add Google Analytics, simply sign up to [Google Analytics](https://www.google.com/analytics/) to obtain your Google Tracking ID, and add this tracking ID to the `google_analytics` parameter in `_config.yml`.

--- a/README.md
+++ b/README.md
@@ -114,16 +114,15 @@ To use Disqus, simply sign up to [Disqus](https://disqus.com/) and add your Disq
 
 To use Facebook comments, create a Facebook app using [Facebook developers](https://developers.facebook.com/docs/apps/register), and add the Facebook App ID to the `fb_comment_id` parameter in `_config.yml`.
 
+#### Utterances comments 
+
+To use [Utterances comments](https://utteranc.es/), follow these steps: (1) Enable Issues in your GitHub repository, (2) Install the Utterances app in your repository (go to https://github.com/apps/utterances), (3) Fill in the `repository` parameter in the utterances section of the `_config.yml` file.
+
 #### Staticman comments
 
 To use Staticman, you first need to invite `staticmanlab` as a collaborator to your repository (by going to your repository **Settings** page, navigate to the **Collaborators** tab, and add the username `staticmanlab`), and then accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`. Lastly, fill in the `staticman` parameters in the Staticman section of `_config.yml`. You may also choose a different Staticman instance other than `staticmanlab`.
 
 Optional: You may want to configure a webhook to prevent old inactive branches (representing approved comments) from stacking up.  You can refer to [Staticman's documentation](https://staticman.net/docs/webhooks) for details.  Make sure to input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com/v3/entry/github/`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
-
-
-### Utterances comments - gitlab issuse
-
-To use utterances(https://github.com/utterance/utterances), you first need prepare a public repo(already existing or create a new) to store comments, and then make sure the [utterances app](https://github.com/apps/utterances) is installed on the repo, otherwise users will not be able to post comments. **Note** If your repo is a fork, navigate to it's settings tab and confirm the issues feature is turned on.  Lastly, fill in the `uttenance` parameters in the Utterances section of `_config.yml`.
 
 
 ### Adding Google Analytics to track page views

--- a/_config.yml
+++ b/_config.yml
@@ -134,17 +134,13 @@ staticman:
     siteKey  : # Use your own site key, you need to apply for one on Google
     secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
-# To use Utterance comments,  you can going to https://utteranc.es/ get more parameters interpretation.
-utterance:
-  # Note: Make sure the repo is public, otherwise your readers will not be able to view the issues/comments.
-  # Make sure the [utterances app](https://github.com/apps/utterances) is installed on the repo, otherwise users will not be able to post comments.
-  #  If your repo is a fork, navigate to it's settings tab and confirm the issues feature is turned on.
-  repo:  # Choose the repository utterances will connect to. eg: owner/repo
-  issue-term: title   # Choose the mapping between blog posts and GitHub issues. eg: pathname, url,specific issue number, etc, going to https://utteranc.es/#Blog Post ↔️ Issue Mapping get more choices.
-  theme: github-light # Choose an Utterances theme that matches your blog. 'github-light' is default
-
-  ## Optional
-  label: blog-comments # Choose the label that will be assigned to issues created by Utterances.
+# To use Utterances comments, fill in repository. See more details about the parameters at https://utteranc.es/
+# Make sure that (1) the repository is public (by defauit it should be), (2) Issues are turned on (if you forked beautiful-jekyll, then by default this will not be true!), (3) You install the Utterances app in your repository https://github.com/apps/utterances
+utterances:
+  repository: # GitHub username/repository eg. "daattali/beautiful-jekyll"
+  issue-term: title   # Mapping between blog posts and GitHub issues
+  theme: github-light # Utterances theme
+  label: blog-comments # Label that will be assigned to GitHub Issues created by Utterances
 
 
 # --- Misc --- #

--- a/_config.yml
+++ b/_config.yml
@@ -139,7 +139,7 @@ utterance:
   # Note: Make sure the repo is public, otherwise your readers will not be able to view the issues/comments.
   # Make sure the [utterances app](https://github.com/apps/utterances) is installed on the repo, otherwise users will not be able to post comments.
   #  If your repo is a fork, navigate to it's settings tab and confirm the issues feature is turned on.
-  repo: colynn/blog-comments # Choose the repository utterances will connect to. eg: owner/repo
+  repo:  # Choose the repository utterances will connect to. eg: owner/repo
   issue-term: title   # Choose the mapping between blog posts and GitHub issues. eg: pathname, url,specific issue number, etc, going to https://utteranc.es/#Blog Post ↔️ Issue Mapping get more choices.
   theme: github-light # Choose an Utterances theme that matches your blog. 'github-light' is default
 

--- a/_config.yml
+++ b/_config.yml
@@ -134,6 +134,19 @@ staticman:
     siteKey  : # Use your own site key, you need to apply for one on Google
     secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
+# To use Utterance comments,  you can going to https://utteranc.es/ get more parameters interpretation.
+utterance:
+  # Note: Make sure the repo is public, otherwise your readers will not be able to view the issues/comments.
+  # Make sure the [utterances app](https://github.com/apps/utterances) is installed on the repo, otherwise users will not be able to post comments.
+  #  If your repo is a fork, navigate to it's settings tab and confirm the issues feature is turned on.
+  repo: colynn/blog-comments # Choose the repository utterances will connect to. eg: owner/repo
+  issue-term: title   # Choose the mapping between blog posts and GitHub issues. eg: pathname, url,specific issue number, etc, going to https://utteranc.es/#Blog Post ↔️ Issue Mapping get more choices.
+  theme: github-light # Choose an Utterances theme that matches your blog. 'github-light' is default
+
+  ## Optional
+  label: blog-comments # Choose the label that will be assigned to issues created by Utterances.
+
+
 # --- Misc --- #
 
 # Facebook App ID

--- a/_config.yml
+++ b/_config.yml
@@ -134,8 +134,8 @@ staticman:
     siteKey  : # Use your own site key, you need to apply for one on Google
     secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
-# To use Utterances comments, fill in repository. See more details about the parameters at https://utteranc.es/
-# Make sure that (1) the repository is public (by defauit it should be), (2) Issues are turned on (if you forked beautiful-jekyll, then by default this will not be true!), (3) You install the Utterances app in your repository https://github.com/apps/utterances
+# To use Utterances comments: (1) fill in repository (make sure the repository is public), (2) Enable Issues in your repository, (3) Install the Utterances app in your repository https://github.com/apps/utterances
+# See more details about the parameters below at https://utteranc.es/
 utterances:
   repository: # GitHub username/repository eg. "daattali/beautiful-jekyll"
   issue-term: title   # Mapping between blog posts and GitHub issues

--- a/_includes/utterances-comment.html
+++ b/_includes/utterances-comment.html
@@ -1,7 +1,7 @@
 {% if site.utterances.repo and site.utterances.issue-term  %}
 
 <script src="https://utteranc.es/client.js"
-        repo="{{site.utterances.repo }}"
+        repository="{{site.utterances.repo }}"
         issue-term="{{ site.utterances.issue-term }}"
         theme="{{ site.utterances.theme}}"
         label="{{ site.utterances.label}}" 

--- a/_includes/utterances-comment.html
+++ b/_includes/utterances-comment.html
@@ -1,10 +1,10 @@
-{% if site.utterance.repo and site.utterance.issue-term  %}
+{% if site.utterances.repo and site.utterances.issue-term  %}
 
 <script src="https://utteranc.es/client.js"
-        repo="{{site.utterance.repo }}"
-        issue-term="{{ site.utterance.issue-term }}"
-        theme="{{ site.utterance.theme}}"
-        label="{{ site.utterance.label}}" 
+        repo="{{site.utterances.repo }}"
+        issue-term="{{ site.utterances.issue-term }}"
+        theme="{{ site.utterances.theme}}"
+        label="{{ site.utterances.label}}" 
         crossorigin="anonymous"
         async>
 </script>

--- a/_includes/utterances-comment.html
+++ b/_includes/utterances-comment.html
@@ -1,0 +1,13 @@
+{% if site.utterance.repo and site.utterance.issue-term  %}
+
+<script src="https://utteranc.es/client.js"
+        repo="{{site.utterance.repo }}"
+        issue-term="{{ site.utterance.issue-term }}"
+        theme="{{ site.utterance.theme}}"
+        label="{{ site.utterance.label}}" 
+        crossorigin="anonymous"
+        async>
+</script>
+
+{% endif %}
+

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,6 +16,7 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
+        {% include utterances-comment.html %}
 	    {% endif %}
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -73,6 +73,7 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
+        {% include utterances-comment.html %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
As we talk in here [add new comments - gitalk support ](https://github.com/daattali/beautiful-jekyll/pull/591),  add #591  @daattali 

Now add [utterances](https://github.com/utterance/utterances) comments widget support.

## Changes
add utterances-comment.html into _includes
change post.html/ page.html link to utterances-comment.html
add utterance parameters into _config.yml and README.md docs

## Demo
You can check the demo from [this website](https://colynn.github.io/aboutme/)