### PR TITLE
Adding Mastodon Social Network Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v3.0.1 (Date: TBD)
 
 - Fixed issue where if a dropdown menu was the last item in the menu bar, it did not have a proper margin on the right
+- Add social network link: Mastodon
 
 ## v3.0.0 (Date: 2020-05-07)
 

--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ social-network-links:
 #  yelp: yourname
 #  telegram: yourname
 #  calendly: yourname
+#  mastodon: instance.url/@username
 
 # --- General options --- #
 

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -228,4 +228,16 @@
   </li>
 {%- endif -%}
 
+{%- if site.social-network-links.mastodon -%}
+  <li class="list-inline-item">
+    <a href="https://{{ site.social-network-links.mastodon }}" title="Mastodon">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-mastodon fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">Mastodon</span>
+    </a>
+  </li>
+{%- endif -%}
+
 </ul>


### PR DESCRIPTION
PR follows discussion at #646 .

Making a PR with only a mastodon link. Looking forward to any comments. A tricky thing is that because mastodon is decentralised there are two things that need to be specified, the hosting instance URL and the username on said instance. I went around this by suggesting the mastodon entry in `_config.yml` be filled in such way that both can be presented as one variable.

P.S. I am not adding a matrix link in this PR because a matrix logo is not included in font-awesome currently. I have [one implementation](https://github.com/Iolaum/beautiful-jekyll/tree/dev_social_matrix) that [uses another non-related picture](https://github.com/Iolaum/beautiful-jekyll/commit/46b1e9f5c7548b0097cc16379f974fbe6930a419) and  a [second implementation](https://github.com/Iolaum/beautiful-jekyll/tree/dev_social_matrix_fa) that [uses fork-awesome to get a matrix logo](https://github.com/Iolaum/beautiful-jekyll/commit/483e40c562e24602134d4dc5ee93f06fdfe0e77e). I 'd be interested if any of those approaches could be considered for inclusion, but given their drawbacks I decided to not include them in the PR.