### PR TITLE
Use Open Graph type 'article' for blog posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed issue where if a dropdown menu was the last item in the menu bar, it did not have a proper margin on the right
 - Add social network link: Mastodon (#646)
 - Add support for sharing pages on new social network: VK (#657)
+- Use Open Graph type 'article' for blog posts (#669)
 
 ## v3.0.0 2020-05-07
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -64,7 +64,13 @@
   {% endif %}
 
 
+  {% if page.id %}
+  <meta property="og:type" content="article">
+  <meta property="og:article:author" content="{{ site.author }}">
+  <meta property="og:article:published_time" content="{{ page.date | date_to_xmlschema }}">
+  {% else %}
   <meta property="og:type" content="website">
+  {% endif %}
 
   {% if page.id %}
   <meta property="og:url" content="{{ page.url | absolute_url }}">


### PR DESCRIPTION
`article` seems to be a more fitting type than `website` for blog posts. See https://ogp.me/#type_article