### PR TITLE
Adds page configuration for description

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ nav-short   | By default, the navigation bar gets shorter after scrolling down t
 gh-repo   | If you want to show GitHub buttons at the top of a post, this sets the GitHub repo name (eg. `daattali/beautiful-jekyll`). You must also use the `gh-badge` parameter to specify what buttons to show.
 gh-badge  | Select which GitHub buttons to display. Available options are: [star, watch, fork, follow]. You must also use the `gh-repo` parameter to specify the GitHub repo.
 layout      | What type of page this is (default is `post` for blog posts and `page` for other pages). See _Page types_ section below for more information. 
+description | A longer description of page or blog post that is used for your meta description content.
 
 ## Advanced parameters
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,12 +3,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <title>{% if page.use-site-title %}{{ site.title }} {{ site.title-separator | default: '-' }} {{ site.description }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-  
+
   {% if site.author %}
   <meta name="author" content="{{ site.author }}">
   {% endif %}
-  
-  {% if page.subtitle %}
+
+  {% if page.description %}
+  <meta name="description" content="{{ page.description }}">
+  {% elsif page.subtitle %}
   <meta name="description" content="{{ page.subtitle }}">
   {% endif %}
 


### PR DESCRIPTION
Sometimes a page subtitle isn't substantive enough to be a good value for a meta description. An optimal length for meta descriptions is usually around 150 characters, which might be too long for a pithy page subtile. In this case I added a `site.description` override that will be used only if provided. Otherwise we fallback to using the subtitle.