### PR TITLE
Adds configuration for additional site css

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,10 @@ footer-link-col: "#404040"
 #footer-img: "/assets/img/bgimage.png"
 #page-img: "/assets/img/bgimage.png"
 
+# You can also include any number of additional CSS assets in every page on your site
+#site-css:
+#  - "/assets/css/my-style.css"
+
 # --- Web Statistics Section --- #
 
 # Fill in your Google Analytics gtag.js ID to track your website using gtag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,6 +42,12 @@
     {% endfor %}
   {% endif %}
 
+  {% if site.site-css %}
+    {% for css in site.site-css %}
+      <link rel="stylesheet" href="{{ css | relative_url }}">
+    {% endfor %}
+  {% endif %}
+
   <!-- Facebook OpenGraph tags -->
   {% if site.fb_app_id %}
   <meta property="fb:app_id" content="{{ site.fb_app_id }}">


### PR DESCRIPTION
Having `page.css` is nice, but there's no way to add css for the entire site. You could just modify `main.css` with the changes you want, but that makes upgrading to the latest from upstream somewhat difficult as you have to deal with potentially complicated merge conflicts. Or you could add the additional css to each and every page, which is annoyingly tedious and human-error prone.

This PR adds a site level configuration for `site-css` that allows you to list additional css files that should be included for every page on the site.