### PR TITLE
Kramdown parser gfm dep

### DIFF
--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.8"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
+  spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
I think this will resolve the build errors we're seeing on the latest PRs. I think one of the existing runtime dependencies must have had `kramdown-parser-gfm` as a dependency, but doesn't any longer? So adding it to our dependency list resolves the issue.