### PR TITLE
Adds og:site_name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased version
 
+- Adds site name OpenGraph configuration.
 - Adds configuration for page text color. (#694)
 - Adds support for site level keywords page meta header. (#691)
 - Adds support for custom meta-theme site color. (#692)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,6 +63,10 @@
   <meta property="fb:app_id" content="{{ site.fb_app_id }}">
   {% endif %}
 
+  {% if site.title %}
+  <meta property="og:site_name" content="{{ site.title }}">
+  {% endif %}
+
   {% if page.meta-title %}
   <meta property="og:title" content="{{ page.meta-title }}">
   {% elsif page.title %}
@@ -71,7 +75,7 @@
   <meta property="og:title" content="{{ site.title }}">
   {% endif %}
 
-   {% if page.meta-description %}
+  {% if page.meta-description %}
   <meta property="og:description" content="{{ page.meta-description }}">
   {% elsif page.subtitle %}
   <meta property="og:description" content="{{ page.subtitle }}">


### PR DESCRIPTION
Adds meta tags for `og:site_name` which will just use the existing `site.title` configuration. Slightly different than `og:title` which can be overridden on a per-page basis. Whereas `og:site_name` will _always_ just be whatever `site.title` has been configured to be.