### PR TITLE
Automatically set navbar light/dark based on color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased version
 
-- Add YAML option `head-extra` which is similar to `footer-extra` but is used to include custom HTML code in a page's `<head>` tag 
+- Add YAML option `head-extra` which is similar to `footer-extra` but is used to include custom HTML code in a page's `<head>` tag
+- Add automatic navbar color detection (#702)
 
 ## v4.1.0 2020-08-08
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -7,14 +7,14 @@ var BeautifulJekyllJS = {
 
   init : function() {
     // Set the navbar-dark/light class based on its background color
-    const rgb = $('.navbar').css("background-color").replace(/[^\d,]/g,'').split(",")
+    const rgb = $('.navbar').css("background-color").replace(/[^\d,]/g,'').split(",");
     const brightness = Math.round(( // http://www.w3.org/TR/AERT#color-contrast
       parseInt(rgb[0]) * 299 +
       parseInt(rgb[1]) * 587 +
-      parseInt(rgb[2]) * 114) / 1000);
+      parseInt(rgb[2]) * 114
+    ) / 1000);
     if (brightness <= 125) {
-      $(".navbar").removeClass("navbar-light");
-      $(".navbar").addClass("navbar-dark");
+      $(".navbar").removeClass("navbar-light").addClass("navbar-dark");
     }
 
     // Shorten the navbar after scrolling a little bit down

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,6 +6,17 @@ var BeautifulJekyllJS = {
   numImgs : null,
 
   init : function() {
+    // Set the navbar-dark/light class based on its background color
+    const rgb = $('.navbar').css("background-color").replace(/[^\d,]/g,'').split(",")
+    const brightness = Math.round(( // http://www.w3.org/TR/AERT#color-contrast
+      parseInt(rgb[0]) * 299 +
+      parseInt(rgb[1]) * 587 +
+      parseInt(rgb[2]) * 114) / 1000);
+    if (brightness <= 125) {
+      $(".navbar").removeClass("navbar-light");
+      $(".navbar").addClass("navbar-dark");
+    }
+
     // Shorten the navbar after scrolling a little bit down
     $(window).scroll(function() {
         if ($(".navbar").offset().top > 50) {


### PR DESCRIPTION
### Description

Pretty simple little bit of javascript to intelligently set the navbar class to either `navbar-light` or `navbar-dark` based on the color of the navbar that the user has configured. This will make it so that navbar elements like the hamburger menu in the mobile site view are easier to see on dark background colors.

### Examples

| Before | After | Result |
| --- | --- | --- |
| ![before-spellbot](https://user-images.githubusercontent.com/1903876/90056946-89007300-dc94-11ea-8b54-888844c46a53.png) | ![after-spellbot](https://user-images.githubusercontent.com/1903876/90056959-90c01780-dc94-11ea-8a1b-07d72f3effc8.png) | actually visible now | 
| ![before-darkblue](https://user-images.githubusercontent.com/1903876/90056991-9a497f80-dc94-11ea-97ef-33acaef317d1.png) | ![after-darkblue](https://user-images.githubusercontent.com/1903876/90056981-974e8f00-dc94-11ea-96a0-5a51b573da42.png) | better visibility |
| ![before-ivory](https://user-images.githubusercontent.com/1903876/90056999-9ae21600-dc94-11ea-9d2f-15e2bd767639.png) | ![after-ivory](https://user-images.githubusercontent.com/1903876/90056998-9ae21600-dc94-11ea-820b-1f1d9afdbc4f.png) | no difference |
| ![before-maroon](https://user-images.githubusercontent.com/1903876/90056994-9a497f80-dc94-11ea-948c-1bf11d90d08c.png) | ![after-maroon](https://user-images.githubusercontent.com/1903876/90056996-9ae21600-dc94-11ea-9ce7-fd40d606792e.png) | better visibility |
| ![before-pink](https://user-images.githubusercontent.com/1903876/90056978-96b5f880-dc94-11ea-8a86-ddcf284421d7.png) | ![after-pink](https://user-images.githubusercontent.com/1903876/90056980-96b5f880-dc94-11ea-9d0b-9b598352f5ee.png) | no difference |

As you can see, for any light colored navbars there's is no difference at all because we will pick `navbar-light` which was the previous default. But for the darker colors the button changes from either completely invisible to actually visible or from hard-to-see to easier-to-see.

### Benefits:

- Users who want to use dark navbar colors are now automatically handled correctly.
- Users don't have to learn about [bootstrap navbar color schemes](https://getbootstrap.com/docs/4.0/components/navbar/#color-schemes) to get dark colored navbars to work.
- Users don't have to modify `_includes/nav.html` to get dark colored navbars to work.
- Users don't have to consider modifying their site css/config files to get their navbar to look good.

Overall this helps non-technical or even just somewhat-technical users of `beautiful-jekyll` to easily have their website do the right thing when they make a trivial configuration change to the navbar color, such as just changing it to a darker color.