### PR TITLE
Fix markdown blockquote css styling

### DIFF
--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -51,7 +51,7 @@ a:focus {
 }
 blockquote {
   color: #808080;
-  font-style: italic;
+  border-left: .25em solid #dfe2e5;
 }
 blockquote p:first-child {
   margin-top: 0;


### PR DESCRIPTION
As I found, [markdown blockquote](https://www.markdownguide.org/basic-syntax/#blockquotes-1) styling defined in `./assets/css/beautifuljekyll.css`:
```css
blockquote {
  color: #808080;
  font-style: italic;
}
```
Does not correspond to what we get in [GFM](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax) formatting:
- border doesn't drawn at the left.
- no need to override and apply italic style to the whole blockquote text.

So, my proposal to change this behaviour to the form (remove font-style, add border-left):
```css
blockquote {
  color: #808080;
  border-left: .25em solid #dfe2e5;
}
```
