### PR TITLE
Update Google Analytics tag (analytics.js) to the latest tag (gtag.js)

### DIFF
--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,14 +1,11 @@
 {% if site.google_analytics %}
-<!-- Google Analytics -->
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-42732221-6"></script>
 <script>
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-  })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-  ga('create', '{{ site.google_analytics }}', 'auto');
-  ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
 </script>
-<!-- End Google Analytics -->
 {% endif %}


### PR DESCRIPTION
Hello

Google has updated the analytics tag (analytics.js) to a new version, the tag (gtag.js). 

This PR replaces the old tag with the new version.

More info about the tag: https://developers.google.com/analytics/devguides/collection/gtagjs

Hugo
