### PR TITLE
fix(#744): Escape special characters in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed bug where using an image as a navbar title did not render in GitHub Project pages that did not have a custom domain
 - Fixed issue where image thumbnails on the feed page were always forced into a square rather than maintaining a proper image aspect ratio
 - Added support for Patreon in the social network links in the footer
+- Fixed bug where special characters in the title led to broken share tags(#744)
 
 ## v5.0.0 (2020-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fixed bug where using an image as a navbar title did not render in GitHub Project pages that did not have a custom domain
 - Fixed issue where image thumbnails on the feed page were always forced into a square rather than maintaining a proper image aspect ratio
 - Added support for Patreon in the social network links in the footer
-- Fixed bug where special characters in the title led to broken share tags(#744)
+- Fixed bug where special characters in the title led to broken share tags (#744)
 
 ## v5.0.0 (2020-09-15)
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,19 +4,19 @@
 
   {% capture title %}
     {%- if page.share-title -%}
-      {{ page.share-title }}
+      {{ page.share-title | strip_html | xml_escape }}
     {%- elsif page.title -%}
-      {{ page.title }}
+      {{ page.title | strip_html | xml_escape  }}
     {%- else -%}
-      {{ site.title }}
+      {{ site.title | strip_html | xml_escape }}
     {%- endif -%}
   {% endcapture %}
 
   {% capture description %}
     {%- if page.share-description -%}
-      {{ page.share-description }}
+      {{ page.share-description | strip_html | xml_escape }}
     {%- elsif page.subtitle -%}
-      {{ page.subtitle }}
+      {{ page.subtitle | strip_html | xml_escape }}
     {%- else -%}
       {%- assign excerpt_length = site.excerpt_length | default: 50 -%}
       {{ page.content | strip_html | xml_escape | truncatewords: excerpt_length | strip }}


### PR DESCRIPTION
Fixes https://github.com/daattali/beautiful-jekyll/issues/744
