### PR TITLE
Remove references to any public Staticman API instance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -161,18 +161,8 @@ footer-link-col: "#404040"
 #  theme: github-light # Utterances theme
 #  label: blog-comments # Label that will be assigned to GitHub Issues created by Utterances
 
-# To quickly use Staticman comments for GitHub, first set up your own instance
-# by clicking the "deploy" button in the project's README:
-# https://github.com/eduardoboucas/staticman/
-# Then create your new private GitHub Apps:
-# https://docs.github.com/en/developers/apps/creating-a-github-app
-# Set the "Homepage URL" to be the URL for your API instance, and the "Webhook
-# URL" to be the URL for your API instance followed by `/v1/webhook`
-# Grant the GitHub App "read & write" permissions for "Contents" and "Pull
-# Requests" and generate a RSA key pair at the bottom of the page.
-# Then configure the necessary environment variables via Heroku's online
-# dashboard: `GITHUB_APP_ID` `GITHUB_PRIVATE_KEY` and `RSA_PRIVATE_KEY`.
-# Then install your GitHub App to your GitHub repo for your site.
+# To use Staticman comments, it's recommended to set up your own API instance.
+# Please consult https://github.com/eduardoboucas/staticman/ for server-side setup.
 # Then uncomment the following section and fill in "repository" and "branch".
 # If you want to use reCaptcha for staticman (optional for spam protection), then fill
 # in the "siteKey" and "secret" parameters below and also in `staticman.yml`.
@@ -180,8 +170,7 @@ footer-link-col: "#404040"
 #staticman:
 #  repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
 #  branch     : master # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-#  endpoint   : # (mandatory) URL of your own deployment, with a trailing slash
-#  e.g. https://<your-api>/v3/entry/github/
+#  endpoint   : # (mandatory) URL of your own deployment, with a trailing slash e.g. https://<your-api>/v3/entry/github/
 #  reCaptcha:
 #    siteKey  : # Use your own site key, you need to apply for one on Google
 #    secret   : # ENCRYPT your password by going to https://<your-own-api>/v3/encrypt/<your-site-secret>

--- a/_config.yml
+++ b/_config.yml
@@ -161,8 +161,18 @@ footer-link-col: "#404040"
 #  theme: github-light # Utterances theme
 #  label: blog-comments # Label that will be assigned to GitHub Issues created by Utterances
 
-# To use Staticman comments, first invite `staticmanlab` as a collaborator to your repository and
-# accept the invitation by going to `https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>`.
+# To quickly use Staticman comments for GitHub, first set up your own instance
+# by clicking the "deploy" button in the project's README:
+# https://github.com/eduardoboucas/staticman/
+# Then create your new private GitHub Apps:
+# https://docs.github.com/en/developers/apps/creating-a-github-app
+# Set the "Homepage URL" to be the URL for your API instance, and the "Webhook
+# URL" to be the URL for your API instance followed by `/v1/webhook`
+# Grant the GitHub App "read & write" permissions for "Contents" and "Pull
+# Requests" and generate a RSA key pair at the bottom of the page.
+# Then configure the necessary environment variables via Heroku's online
+# dashboard: `GITHUB_APP_ID` `GITHUB_PRIVATE_KEY` and `RSA_PRIVATE_KEY`.
+# Then install your GitHub App to your GitHub repo for your site.
 # Then uncomment the following section and fill in "repository" and "branch".
 # If you want to use reCaptcha for staticman (optional for spam protection), then fill
 # in the "siteKey" and "secret" parameters below and also in `staticman.yml`.
@@ -170,10 +180,11 @@ footer-link-col: "#404040"
 #staticman:
 #  repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
 #  branch     : master # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-#  endpoint   : # (optional) URL of your own deployment, with a trailing slash eg. https://<your-api>/v3/entry/github/ (will fallback to a public GitLab instance)
+#  endpoint   : # (mandatory) URL of your own deployment, with a trailing slash
+#  e.g. https://<your-api>/v3/entry/github/
 #  reCaptcha:
 #    siteKey  : # Use your own site key, you need to apply for one on Google
-#    secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
+#    secret   : # ENCRYPT your password by going to https://<your-own-api>/v3/encrypt/<your-site-secret>
 
 # --- Misc --- #
 

--- a/_config.yml
+++ b/_config.yml
@@ -161,19 +161,19 @@ footer-link-col: "#404040"
 #  theme: github-light # Utterances theme
 #  label: blog-comments # Label that will be assigned to GitHub Issues created by Utterances
 
-# To use Staticman comments, it's recommended to set up your own API instance.
-# Please consult https://github.com/eduardoboucas/staticman/ for server-side setup.
-# Then uncomment the following section and fill in "repository" and "branch".
-# If you want to use reCaptcha for staticman (optional for spam protection), then fill
-# in the "siteKey" and "secret" parameters below and also in `staticman.yml`.
-# See more details at https://staticman.net/
+# To use Staticman comments, uncomment the following section. You may leave the reCaptcha
+# section commented if you aren't using reCaptcha for spam protection. 
+# Using Staticman requires advanced knowledge, please consult 
+# https://github.com/eduardoboucas/staticman/ and https://staticman.net/ for further 
+# instructions. For any support with staticman please direct questions to staticman and 
+# not to BeautifulJekyll.
 #staticman:
 #  repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
 #  branch     : master # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-#  endpoint   : # (mandatory) URL of your own deployment, with a trailing slash e.g. https://<your-api>/v3/entry/github/
-#  reCaptcha:
-#    siteKey  : # Use your own site key, you need to apply for one on Google
-#    secret   : # ENCRYPT your password by going to https://<your-own-api>/v3/encrypt/<your-site-secret>
+#  endpoint   : # URL of your deployment, with a trailing slash eg. "https://<your-api>/v3/entry/github/"
+#  reCaptcha:   # (optional, set these parameters in `staticman.yml` as well) 
+#    siteKey  : # You need to apply for a site key on Google
+#    secret   : # Encrypt your password by going to https://<your-own-api>/v3/encrypt/<your-site-secret>
 
 # --- Misc --- #
 

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -11,7 +11,7 @@ layout: null
     $(form).addClass('disabled');
 
     {% assign sm = site.staticman -%}
-    var endpoint = '{{ sm.endpoint | default: "https://staticman3.herokuapp.com/v3/entry/github/" }}';
+    var endpoint = '{{ sm.endpoint }}';
     var repository = '{{ sm.repository }}';
     var branch = '{{ sm.branch }}';
 

--- a/staticman.yml
+++ b/staticman.yml
@@ -5,7 +5,7 @@
 # To encrypt strings use the following endpoint:
 # https://{STATICMAN API INSTANCE}/v3/encrypt/{TEXT TO BE ENCRYPTED}
 # {STATICMAN API INSTANCE} should match the `endpoint` in the theme config
-# file. It defaults to "staticman3.herokuapp.com".
+# file.
 
 comments:
   # (*) REQUIRED


### PR DESCRIPTION
# Goal

1. Resolves #541
2. Update the instructions for Staticman in the sample config file `_config.yml` so that it complies with Staticman's maintainer's recommendations to
    + use self-hosted instances
    + avoid any public API instances in https://github.com/eduardoboucas/staticman/issues/317#issuecomment-565250060.
3. Seize this chance to announce the end-of-service of my "bot" @<span>staticmanlab</span> on GitHub.

# Description

1. Removes all fallback/default to my Staticman instance `staticman3.herokuapp.com`.
2. Added a brief description about
    1. one-click deploy to Heroku ![Deploy](https://www.herokucdn.com/deploy/button.svg).
    2. GitHub App creation: https://docs.github.com/en/developers/apps/creating-a-github-app, thanks to https://hajekj.net/2020/04/15/staticman-setup-in-app-service/.
    3. Heroku app online dashboard config variables for the Heroku App

        ![screenshot of Heroku's dashboard](https://user-images.githubusercontent.com/5748535/106462435-5e021980-6496-11eb-9c60-05471c067bff.png)

        + `NODE_ENV`: `production`
        + `GITHUB_PRIVATE_KEY`: click the :pen: to paste the content of the RSA private key PEM file _downloaded_  from the GitHub App's settings page.
        + `RSA_PRIVATE_KEY`: click the :pen: to paste the content of your (_locally generated_) RSA private key PEM file.

        ![screenshot of RSA private key on Heroku's dashboard](https://user-images.githubusercontent.com/5748535/106461761-82a9c180-6495-11eb-95ce-72fd8f11f768.png)

    4. Installation of the private GitHub App to the GitHub repo for the Beautiful Jekyll site

# Test

I have only tested my instructions this morning in my Jekyll+Staticman MWE: https://git.io/smdemo: https://github.com/VincentTam/TestStaticmanLab/pull/95.

![Screenshot from 2021-02-01 11-36-53](https://user-images.githubusercontent.com/5748535/106447729-21c4be00-6482-11eb-83d9-c200f4a34a83.png)
![Screenshot from 2021-02-01 11-32-49](https://user-images.githubusercontent.com/5748535/106447733-22f5eb00-6482-11eb-99bc-8232cb96f664.png)

The linked PR in my MWE is "authored" by a "bot", which is the GitHub App "secretman3"

# Critique

I've omitted the instructions for GitLab, for which I opened #510.  Without a project wiki and with Staticman instructions removed from README, there're only two places left for instructions:

1. comments in the site config file `_config.yml`: contains everything about the Staticman setup except reCAPTCHA
2. comments in the Staticman config file `staticman.yml`: contains reCAPTCHA v2 support for Staticman

I've put everything about the GitHub App setup in `_config.yml`.  I'm worried that for users who don't use Staticman, it might be to much to have to another section about the GitLab collaborator bot.  I leave this out for the moment.