### PR TITLE
feat(includes): added related post feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,30 @@
 
 ## Table of contents
 
+- [Beautiful Jekyll](#beautiful-jekyll)
+  - [Table of contents](#table-of-contents)
 - [Features](#features)
-- [Sponsors 🏆](#sponsors)
-- [**Build your website in 3 steps**](#build-your-website-in-3-steps)
+- [Build your website in 3 steps](#build-your-website-in-3-steps)
+  - [The easy way (recommended!)](#the-easy-way-recommended)
+    - [1. Fork this project](#1-fork-this-project)
+    - [2. Rename the project to `<yourusername>.github.io`](#2-rename-the-project-to-yourusernamegithubio)
+    - [3. Customize your website settings](#3-customize-your-website-settings)
+    - [4. Congratulations! You have a website!](#4-congratulations-you-have-a-website)
+  - [The hard way (using ruby gems)](#the-hard-way-using-ruby-gems)
 - [Plans](#plans)
 - [Add your own content](#add-your-own-content)
 - [Customizing parameters for each page](#customizing-parameters-for-each-page)
 - [Supported parameters](#supported-parameters)
+  - [Main parameters](#main-parameters)
+  - [Parameters for SEO and social media sharing](#parameters-for-seo-and-social-media-sharing)
+  - [Parameters for Related Posts](#parameters-for-related-posts)
+  - [Less commonly used parameters](#less-commonly-used-parameters)
+  - [Advanced parameters](#advanced-parameters)
+  - [Page types](#page-types)
 - [Featured users (success stories!)](#featured-users-success-stories)
 - [FAQ and support](#faq-and-support)
-- [Credits and contributions](#credits)
+- [Contributions](#contributions)
+- [Credits](#credits)
 
 # Features
 
@@ -39,6 +53,7 @@ Check out [*What's New?*](https://beautifuljekyll.com/updates/) to see the lates
 - **Tags**: Any blog post can be tagged with keywords, and an index page showing all the tags is automatically generated.
 - **Analytics**: Easily integrate Google Analytics, or other analytics platforms, to track visits to your website.
 - **Photos support**: Any page can have a full-width cover photo and thumbnail.
+- **Related posts** Any blog post can show related posts that increases traffic and engagements to your site.
 - **RSS**: An RSS feed is automatically created, so you can even host a podcast easily with Beautiful Jekyll.
 
 <h2 id="sponsors">Sponsors 🏆</h2>
@@ -153,6 +168,34 @@ Parameter   | Description
 share-title | A title for the page. If not provided, then `title` will be used, and if that's missing then the site title (from `_config.yml`) is used.
 share-description | A brief description of the page. If not provided, then `subtitle` will be used, and if that's missing then an excerpt from the page content is used.
 share-img   | The image to show. If not provided, then `cover-img` or `thumbnail-img` will be used if one of them is provided.
+
+## Parameters for Related Posts
+
+Show related posts in your blogs. This feature works on GitHub Pages as well! Here are the default values for parameters:
+
+```yaml
+related-posts:
+  enabled: true
+  max-related: 4
+  min-common-tags: 1
+  title: Read next
+
+```
+
+Parameter   | Description
+----------- | -----------
+title | A title text displayed on top of related posts. Default title text is `Read next`.
+enabled | Flag to disable related posts from all posts by default it is `true` in `_config.yml` file.
+max-related | Maximum number of matching posts to be displayed. Default value is `4`.
+min-common-tags   | Minimum Number of common tags to search for matching blog post. Default value is `1`.
+
+Example of Related Posts: 
+```yaml
+related-posts:
+  enabled: true
+  max-related: 2
+```
+![](https://i.imgur.com/VP1UdJZ.png)
 
 ## Less commonly used parameters
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Developing and maintaining Beautiful Jekyll takes a lot of time and effort - tha
 
 # Build your website in 3 steps
 
-There's a very easy way to use this theme, and there's a hard way. For most people (including myself!), I suggest going the easy route. If you're an advanced user and want to tinker with the hard way (using ruby gems), then [skip the easy way](https://github.com/daattali/beautiful-jekyll#the-hard-way-using-ruby-gems) if you know what you're doing.
+There's a very easy way to use this theme, and there's a hard way. For most people (including myself!), the easy route is recommended. If you're an advanced user and want to tinker with the hard way (using ruby gems), then [skip the easy way](https://github.com/daattali/beautiful-jekyll#the-hard-way-using-ruby-gems) if you know what you're doing.
 
 ## The easy way (recommended!)
 
@@ -72,9 +72,9 @@ Click on __*Settings*__ at the top (the cog icon) and on that page you'll have a
 
 ### 3. Customize your website settings
 
-Edit the `_config.yml` file to change any settings you want. To edit the file, click on it to view the file and then click on the pencil icon to edit it (watch the video tutorial above if you're confused).  The settings in the file are self-explanatory and I added comments inside the file to help you understand what each setting does. Any line that begins with a hashtag (`#`) is a comment, and the other lines are actual settings.
+Edit the `_config.yml` file to change any settings you want. To edit the file, click on it to view the file and then click on the pencil icon to edit it (watch the video tutorial above if you're confused).  The settings in the file are self-explanatory and there are comments inside the file to help you understand what each setting does. Any line that begins with a hashtag (`#`) is a comment, and the other lines are actual settings.
 
-Note that in the video above I only edited one setting in the `_config.yml` file. **You should actually go through the rest of the settings as well. Don't be lazy, go through all the settings!**
+Note that in the video above only one setting in the `_config.yml` file is edited. **You should actually go through the rest of the settings as well. Don't be lazy, go through all the settings!**
 
 ### 4. Congratulations! You have a website!
 
@@ -88,11 +88,11 @@ If you followed the easy method above, then you already have your site and you c
 
 # Plans
 
-Beautiful Jekyll is, and always will be, free. But if you want to remove the Beautiful Jekyll ad from your website, use a Dark Mode skin, unlock other special rewards, or simply support my development efforts, [check out the different plans](https://beautifuljekyll.com/plans).
+Beautiful Jekyll is, and always will be, free. But if you want to remove the Beautiful Jekyll ad from your website, use a Dark Mode skin, unlock other special rewards, or simply support the development efforts, [check out the different plans](https://beautifuljekyll.com/plans).
 
 # Add your own content
 
-To add pages to your site, you can either write a markdown file (`.md`) or you can write an HTML file. It's much easier to write markdown than HTML, so I suggest you do that ([here's a great tutorial](https://markdowntutorial.com/) if you need to learn markdown in 5 minutes).
+To add pages to your site, you can either write a markdown file (`.md`) or you can write an HTML file. It's much easier to write markdown than HTML, so that's the recommended approach ([here's a great tutorial](https://markdowntutorial.com/) if you need to learn markdown in 5 minutes).
 
 To see an example of a markdown file, click on any file that ends in `.md`, for example [`aboutme.md`](./aboutme.md). On that page you can see some nicely formatted text (there's a word in bold, a link, a few bullet points), and if you click on the pencil icon to edit the file, you'll see the markdown code that generated the pretty text. Very easy!
 

--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,6 @@ round-avatar: true
 # then specify the following parameter
 #title-img: /path/to/image
 
-
 # --- Footer social media links --- #
 
 # Select the social network links that you want to show in the footer.
@@ -87,6 +86,10 @@ feed_show_excerpt: true
 
 # Whether or not to show a list of tags below each post preview in the feed page
 feed_show_tags: true
+
+# Related Posts on each blog post
+related-posts:
+  enabled: true
 
 # The keywords to associate with your website, for SEO purposes
 #keywords: "my,list,of,keywords"
@@ -197,16 +200,14 @@ kramdown:
 
 # Default YAML values (more information on Jekyll's site)
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
       type: "posts"
     values:
       layout: "post"
-      comments: true  # add comments to all blog posts
+      comments: true # add comments to all blog posts
       social-share: true # add social media sharing buttons to all blog posts
-  -
-    scope:
+  - scope:
       path: "" # any file that's not a post will be a "page" layout by default
     values:
       layout: "page"
@@ -225,7 +226,6 @@ exclude:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
-
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189
 

--- a/_includes/related.html
+++ b/_includes/related.html
@@ -1,0 +1,111 @@
+<div class="posts-list">
+
+    <h2>{{% site.related-posts.title | default:'Read next' %}}</h2>
+
+    {% assign maxRelated = site.related-posts.max-related | default:4 %}
+    {% assign minCommonTags = site.related-posts.min-common-tags | default: 1 %}
+    {% assign maxRelatedCounter = 0 %}
+
+
+    {% for post in site.posts %}
+
+
+    {% assign sameTagCount = 0 %}
+    {% assign commonTags = '' %}
+
+    {% for tag in post.tags %}
+    {% if post.url != page.url %}
+    {% if page.tags contains tag %}
+    {% assign sameTagCount = sameTagCount | plus: 1 %}
+    {% capture tagmarkup %} <span class="label label-default">{{ tag }}</span> {% endcapture %}
+    {% assign commonTags = commonTags | append: tagmarkup %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+
+    {% if sameTagCount >= minCommonTags %}
+
+    <article class="post-preview">
+        {%- capture thumbnail -%}
+        {% if post.thumbnail-img %}
+        {{ post.thumbnail-img }}
+        {% elsif post.cover-img %}
+        {% if post.cover-img.first %}
+        {{ post.cover-img[0].first.first }}
+        {% else %}
+        {{ post.cover-img }}
+        {% endif %}
+        {% else %}
+        {% endif %}
+        {% endcapture %}
+        {% assign thumbnail=thumbnail | strip %}
+
+        {% if site.feed_show_excerpt == false %}
+        {% if thumbnail != "" %}
+        <div class="post-image post-image-normal">
+            <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
+                <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+            </a>
+        </div>
+        {% endif %}
+        {% endif %}
+
+        <a href="{{ post.url | absolute_url }}">
+            <h3 class="post-title">{{ post.title }}</h3>
+
+            {% if post.subtitle %}
+            <h4 class="post-subtitle">
+                {{ post.subtitle }}
+            </h4>
+            {% endif %}
+        </a>
+
+        <p class="post-meta">
+            {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
+            Posted on {{ post.date | date: date_format }}
+        </p>
+
+        {% if thumbnail != "" %}
+        <div class="post-image post-image-small">
+            <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
+                <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+            </a>
+        </div>
+        {% endif %}
+
+        {% unless site.feed_show_excerpt == false %}
+        {% if thumbnail != "" %}
+        <div class="post-image post-image-short">
+            <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
+                <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+            </a>
+        </div>
+        {% endif %}
+
+        <div class="post-entry">
+            {% assign excerpt_length = site.excerpt_length | default: 50 %}
+            {{ post.excerpt | strip_html | xml_escape | truncatewords: excerpt_length }}
+            {% assign excerpt_word_count = post.excerpt | number_of_words %}
+            {% if post.content != post.excerpt or excerpt_word_count > excerpt_length %}
+            <a href="{{ post.url | absolute_url }}" class="post-read-more">[Read&nbsp;More]</a>
+            {% endif %}
+        </div>
+        {% endunless %}
+
+        {% if site.feed_show_tags != false and post.tags.size > 0 %}
+        <div class="blog-tags">
+            <span>Tags:</span>
+            {% for tag in post.tags %}
+            <a href="{{ '/tags' | absolute_url }}#{{- tag -}}">{{- tag -}}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </article>
+
+    {% assign maxRelatedCounter = maxRelatedCounter | plus: 1 %}
+    {% if maxRelatedCounter >= maxRelated %}
+    {% break %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -77,6 +77,9 @@ layout: base
         {% endif %}
       </ul>
       {% include comments.html %}
+      {% if site.related-posts.enabled %}
+      {% include related.html %}
+      {% endif %}
     </div>
   </div>
 </div>

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
+  ## Windows developer needs below dependencies: 
   spec.add_development_dependency 'tzinfo-data'
   spec.add_development_dependency 'wdm'
   spec.add_development_dependency 'webrick'

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -25,4 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency 'tzinfo-data'
+  spec.add_development_dependency 'wdm'
+  spec.add_development_dependency 'webrick'
 end
+


### PR DESCRIPTION
Hi @daattali 
I want to show related posts at the end of the blog. 
This is how it looks in beautiful-jekyll official testing blog
![image](https://user-images.githubusercontent.com/330383/107072215-d2e59400-67b3-11eb-931e-dc0920450313.png)

I implemented in my site and this is how it looks. 
![image](https://user-images.githubusercontent.com/330383/107072286-ed1f7200-67b3-11eb-8f76-192bc2daf064.png)

I updated the readme file as well
![image](https://user-images.githubusercontent.com/330383/107072758-6f0f9b00-67b4-11eb-95f5-c4127fa22c41.png)

