### PR TITLE
replaced ajax for compatibility with jQuery slim

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -14,29 +14,42 @@ layout: null
     var endpoint = '{{ sm.endpoint }}';
     var repository = '{{ sm.repository }}';
     var branch = '{{ sm.branch }}';
+    let url = endpoint + repository + '/' + branch + '/comments';
+    let data = $(this).serialize();
 
-    $.ajax({
-      type: $(this).attr('method'),
-      url: endpoint + repository + '/' + branch + '/comments',
-      data: $(this).serialize(),
-      contentType: 'application/x-www-form-urlencoded',
-      success: function (data) {
-        $('#comment-form-submit').addClass('d-none');
-        $('#comment-form-submitted').removeClass('d-none');
-        $('.page__comments-form .js-notice').removeClass('alert-danger');
-        $('.page__comments-form .js-notice').addClass('alert-success');
-        showAlert('success');
-      },
-      error: function (err) {
-        console.log(err);
-        $('#comment-form-submitted').addClass('d-none');
-        $('#comment-form-submit').removeClass('d-none');
-        $('.page__comments-form .js-notice').removeClass('alert-success');
-        $('.page__comments-form .js-notice').addClass('alert-danger');
-        showAlert('failure');
-        $(form).removeClass('disabled');
+    fetch(url, {
+      method: "POST",
+      body: data,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
       }
+    }).then(function(res) {
+      if (res.ok) {
+        formSubmitted();
+      } else {
+        formError();
+      }
+    }).catch(function(error) {
+      formError();
+      console.log(error);
     });
+
+    function formSubmitted() {
+      $('#comment-form-submit').addClass('d-none');
+      $('#comment-form-submitted').removeClass('d-none');
+      $('.page__comments-form .js-notice').removeClass('alert-danger');
+      $('.page__comments-form .js-notice').addClass('alert-success');
+      showAlert('success');
+    }
+
+    function formError() {
+      $('#comment-form-submitted').addClass('d-none');
+      $('#comment-form-submit').removeClass('d-none');
+      $('.page__comments-form .js-notice').removeClass('alert-success');
+      $('.page__comments-form .js-notice').addClass('alert-danger');
+      showAlert('failure');
+      $(form).removeClass('disabled');
+    }
 
     return false;
   });


### PR DESCRIPTION
**Edited: I prefer merging <span>#</span>782**

# Goal

To resolve #766 

# Background

Brief evolution history of the part of code concerned for Staticman integration over the past year:

1. I ported <span>@</span>mmistakes's code in <span>#</span>440 and <span>#</span>444 for Staticman integration (in response to <span>#</span>115).
https://github.com/daattali/beautiful-jekyll/blob/3a45190a5975cf10484455b8a6cf640ac0b2c6a4/_includes/staticman-script.html#L4-L6
2. I moved the JS code in Staticman integration from the Jekyll-HTML template file into a JS file in <span>#</span>521, so that the JS code is found under a more logical location.
3. The jQuery imported in item&nbsp;1 was replaced by its slim version at https://github.com/daattali/beautiful-jekyll/commit/5991966d38054938fa0506414b9f7e1c10946340#diff-e9c677c6d71b6acd8eb0963e0e2a9bd997a86240a3711c2d391c42d18eb12c32.

# Description

The `ajax` method used by jQuery can be replaced by the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) method, which belongs to standard JS.  In this way, the problem would be gone.

# Testing

To properly test this PR, you need a working Staticman API instance.  I've inactivated mine <span>@</span>staticmanlab due to Staticman's maintainer's advice to move away from any public API instances in the comments in eduardoboucas/staticman<span>#</span>337.  For a Staticman API instance setup guide, you may see, for example, what I've written in https://github.com/daattali/beautiful-jekyll/pull/775, or https://github.com/pacollins/hugo-future-imperfect-slim/wiki/staticman.yml, which are inspired by [Jan Hajek's article about Staticman v3](https://hajekj.net/2020/04/15/staticman-setup-in-app-service/).

1. I've merged the `sm3slim` branch into the `gh-pages` branch for my fork of this theme:

    https://github.com/VincentTam/beautiful-jekyll/compare/e37a4fda58942d408b1ba4e267ecd04ed582ca7d...VincentTam:bccdcafb.

    P.S. I had made a careless mistake in the `endpoint` site config variable while merging the recent development into my `gh-pages` branch.  I corrected that at bccdcafb.

2. Make sure that you've correctly filled in the theme-specific site config.  Here's the one used in this test.

    ```yml
    # To use Staticman comments, uncomment the following section. You may leave the reCaptcha
    # section commented if you aren't using reCaptcha for spam protection. 
    # Using Staticman requires advanced knowledge, please consult 
    # https://github.com/eduardoboucas/staticman/ and https://staticman.net/ for further 
    # instructions. For any support with staticman please direct questions to staticman and 
    # not to BeautifulJekyll.
    staticman:
      repository : vincenttam/beautiful-jekyll # GitHub username/repository eg. "daattali/beautiful-jekyll"
      branch     : gh-pages # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
      endpoint   : https://secretman3.herokuapp.com/v3/entry/github/ # URL of your deployment, with a trailing slash eg. "https://<your-api>/v3/entry/github/"
    #  reCaptcha:   # (optional, set these parameters in `staticman.yml` as well) 
    #    siteKey  : # You need to apply for a site key on Google
    #    secret   : # Encrypt your password by going to https://<your-own-api>/v3/encrypt/<your-site-secret>
    ```

3. I sent a sample message through my online form on my testing site : https://git.io/bjsm18.

    ![Screenshot from 2021-02-09 13-42-12](https://user-images.githubusercontent.com/5748535/107372182-6c2ee600-6ae5-11eb-91c1-811baa9e7298.png)

    | fields | value |
    | :--- | :---- |
    | `fields[message]` | `new post method` |
    | `fields[name` | `Vincent Tam` |
    | `fields[email]` | `xxxx@live.hk` |
    | `fields[url]` | `https://vincentkltam.gitlab.io` |
    | `options[origin]` | `https://vincenttam.github.io/beautiful-jekyll/2020-02-28-test-markdown/` |
    | `options[slug]` | `test-markdown` |

4. I observed a success message.  My Staticman API's (`secretman3 d0τ herokuapp d0t com`) response:

    ```json
    {
      "success":true,
      "fields":{
        "message":"new post method",
        "name":"Vincent Tam",
        "email":"4980f828b9588a712cc2013ac10fd13a",
        "url":"https://vincentkltam.gitlab.io",
        "hidden":"",
        "date":"2021-02-09T12:41:42.498Z"
      }
    }
    ```

5. Successful PR: https://github.com/VincentTam/beautiful-jekyll/pull/35

P.S. I made error in the `endpoint` variable at https://github.com/VincentTam/beautiful-jekyll/commit/f90ee575c4655c7224dcb3f2c97057d6a07c618f#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R183.  That enabled me to view the displayed error message after merging the `sm3slim` branch at 36e8bca before correct that variable at the following commit.