### PR TITLE
IE & jQuery slim compatible Staticman JS

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -14,29 +14,40 @@ layout: null
     var endpoint = '{{ sm.endpoint }}';
     var repository = '{{ sm.repository }}';
     var branch = '{{ sm.branch }}';
+    let url = endpoint + repository + '/' + branch + '/comments';
+    let data = $(this).serialize();
 
-    $.ajax({
-      type: $(this).attr('method'),
-      url: endpoint + repository + '/' + branch + '/comments',
-      data: $(this).serialize(),
-      contentType: 'application/x-www-form-urlencoded',
-      success: function (data) {
-        $('#comment-form-submit').addClass('d-none');
-        $('#comment-form-submitted').removeClass('d-none');
-        $('.page__comments-form .js-notice').removeClass('alert-danger');
-        $('.page__comments-form .js-notice').addClass('alert-success');
-        showAlert('success');
-      },
-      error: function (err) {
-        console.log(err);
-        $('#comment-form-submitted').addClass('d-none');
-        $('#comment-form-submit').removeClass('d-none');
-        $('.page__comments-form .js-notice').removeClass('alert-success');
-        $('.page__comments-form .js-notice').addClass('alert-danger');
-        showAlert('failure');
-        $(form).removeClass('disabled');
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", url);
+    xhr.onreadystatechange = function () {
+      if(xhr.readyState === XMLHttpRequest.DONE) {
+        var status = xhr.status;
+        if (status >= 200 && status < 400) {
+          formSubmitted();
+        } else {
+          formError();
+        }
       }
-    });
+    };
+
+    function formSubmitted() {
+      $('#comment-form-submit').addClass('d-none');
+      $('#comment-form-submitted').removeClass('d-none');
+      $('.page__comments-form .js-notice').removeClass('alert-danger');
+      $('.page__comments-form .js-notice').addClass('alert-success');
+      showAlert('success');
+    }
+
+    function formError() {
+      $('#comment-form-submitted').addClass('d-none');
+      $('#comment-form-submit').removeClass('d-none');
+      $('.page__comments-form .js-notice').removeClass('alert-success');
+      $('.page__comments-form .js-notice').addClass('alert-danger');
+      showAlert('failure');
+      $(form).removeClass('disabled');
+    }
+
+    xhr.send(data);
 
     return false;
   });

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -19,6 +19,8 @@ layout: null
 
     var xhr = new XMLHttpRequest();
     xhr.open("POST", url);
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     xhr.onreadystatechange = function () {
       if(xhr.readyState === XMLHttpRequest.DONE) {
         var status = xhr.status;


### PR DESCRIPTION
# Goal

To resolve #766 in an IE-compatible way.

:warning: Merge either this PR or #781.  **Don't merge both.**

Background, description idem to linked PR.

# Testing
## Procedures

To save time, I did a Git merge on my demo site (https://git.io/bjsm0).  To see the difference, you may run https://github.com/VincentTam/beautiful-jekyll/compare/e37a4fda...ee14efae.

```diff
diff --git a/assets/js/staticman.js b/assets/js/staticman.js
index e8bdfbe..b52708f 100644
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -14,29 +14,42 @@ layout: null
     var endpoint = '{{ sm.endpoint }}';
     var repository = '{{ sm.repository }}';
     var branch = '{{ sm.branch }}';
+    let url = endpoint + repository + '/' + branch + '/comments';
+    let data = $(this).serialize();
 
-    $.ajax({
-      type: $(this).attr('method'),
-      url: endpoint + repository + '/' + branch + '/comments',
-      data: $(this).serialize(),
-      contentType: 'application/x-www-form-urlencoded',
-      success: function (data) {
-        $('#comment-form-submit').addClass('d-none');
-        $('#comment-form-submitted').removeClass('d-none');
-        $('.page__comments-form .js-notice').removeClass('alert-danger');
-        $('.page__comments-form .js-notice').addClass('alert-success');
-        showAlert('success');
-      },
-      error: function (err) {
-        console.log(err);
-        $('#comment-form-submitted').addClass('d-none');
-        $('#comment-form-submit').removeClass('d-none');
-        $('.page__comments-form .js-notice').removeClass('alert-success');
-        $('.page__comments-form .js-notice').addClass('alert-danger');
-        showAlert('failure');
-        $(form).removeClass('disabled');
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", url);
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    xhr.onreadystatechange = function () {
+      if(xhr.readyState === XMLHttpRequest.DONE) {
+        var status = xhr.status;
+        if (status >= 200 && status < 400) {
+          formSubmitted();
+        } else {
+          formError();
+        }
       }
-    });
+    };
+
+    function formSubmitted() {
+      $('#comment-form-submit').addClass('d-none');
+      $('#comment-form-submitted').removeClass('d-none');
+      $('.page__comments-form .js-notice').removeClass('alert-danger');
+      $('.page__comments-form .js-notice').addClass('alert-success');
+      showAlert('success');
+    }
+
+    function formError() {
+      $('#comment-form-submitted').addClass('d-none');
+      $('#comment-form-submit').removeClass('d-none');
+      $('.page__comments-form .js-notice').removeClass('alert-success');
+      $('.page__comments-form .js-notice').addClass('alert-danger');
+      showAlert('failure');
+      $(form).removeClass('disabled');
+    }
+
+    xhr.send(data);
 
     return false;
   });
```

## Screenshots and results

Screenshots to be uploaded in a few hours.

Success: https://github.com/VincentTam/beautiful-jekyll/pull/36

# References

1. https://attacomsian.com/blog/xhr-post-request
2. https://stackoverflow.com/a/10876284/3184351
3. https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/onreadystatechange