### PR TITLE
use base_url as default when absolute is null

### DIFF
--- a/_includes/footer-minimal.html
+++ b/_includes/footer-minimal.html
@@ -12,7 +12,7 @@
 
     {% if site.url-pretty %}
       &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-      <a href="{{ '/' base_url | absolute_url }}">{{ site.url-pretty }}</a>
+      <a href="{{ '/' | absolute_url }}">{{ site.url-pretty }}</a>
     {% endif %}
   </div>
 </footer>

--- a/_includes/footer-minimal.html
+++ b/_includes/footer-minimal.html
@@ -12,7 +12,7 @@
 
     {% if site.url-pretty %}
       &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-      <a href="{{ '' | absolute_url }}">{{ site.url-pretty }}</a>
+      <a href="{{ '/' base_url | absolute_url }}">{{ site.url-pretty }}</a>
     {% endif %}
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,7 +20,7 @@
       {% if site.url-pretty %}
         &nbsp;&bull;&nbsp;
         <span class="author-site">
-          <a href="{% if site.url-canonical %}{{ site.url-canonical }}{% else %}{{ '/' base_url | absolute_url }}{% endif %}">{{ site.url-pretty }}</a>
+          <a href="{% if site.url-canonical %}{{ site.url-canonical }}{% else %}{{ '/' | absolute_url }}{% endif %}">{{ site.url-pretty }}</a>
         </span>
       {% endif %}
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,7 +20,7 @@
       {% if site.url-pretty %}
         &nbsp;&bull;&nbsp;
         <span class="author-site">
-          <a href="{% if site.url-canonical %}{{ site.url-canonical }}{% else %}{{ '' | absolute_url }}{% endif %}">{{ site.url-pretty }}</a>
+          <a href="{% if site.url-canonical %}{{ site.url-canonical }}{% else %}{{ '/' base_url | absolute_url }}{% endif %}">{{ site.url-pretty }}</a>
         </span>
       {% endif %}
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,9 +1,9 @@
 <nav class="navbar navbar-expand-xl navbar-light fixed-top navbar-custom {% if page.nav-short %}top-nav-short-permanent{% else %}top-nav-regular{% endif %}">
 
   {%- if site.title-img -%}
-    <a class="navbar-brand navbar-brand-logo" href="{{ '/' base_url | absolute_url }}"><img alt="{{ site.title }} Logo" src="{{ site.title-img | relative_url}}"/></a>
+    <a class="navbar-brand navbar-brand-logo" href="{{ '/' | absolute_url }}"><img alt="{{ site.title }} Logo" src="{{ site.title-img | relative_url}}"/></a>
   {%- elsif site.title -%}
-    <a class="navbar-brand" href="{{ '/' base_url | absolute_url }}">{{ site.title }}</a>
+    <a class="navbar-brand" href="{{ '/' | absolute_url }}">{{ site.title }}</a>
   {%- endif -%}
 
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main-navbar" aria-controls="main-navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -42,7 +42,7 @@
   {% if site.avatar and page.show-avatar != false %}
     <div class="avatar-container">
       <div class="avatar-img-border">
-        <a href="{{ '/' base_url | absolute_url }}">
+        <a href="{{ '/' | absolute_url }}">
           <img alt="Navigation bar avatar" class="avatar-img" src="{{ site.avatar | relative_url }}" />
         </a>
       </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,9 +1,9 @@
 <nav class="navbar navbar-expand-xl navbar-light fixed-top navbar-custom {% if page.nav-short %}top-nav-short-permanent{% else %}top-nav-regular{% endif %}">
 
   {%- if site.title-img -%}
-    <a class="navbar-brand navbar-brand-logo" href="{{ '' | absolute_url }}"><img alt="{{ site.title }} Logo" src="{{ site.title-img | relative_url}}"/></a>
+    <a class="navbar-brand navbar-brand-logo" href="{{ '/' base_url | absolute_url }}"><img alt="{{ site.title }} Logo" src="{{ site.title-img | relative_url}}"/></a>
   {%- elsif site.title -%}
-    <a class="navbar-brand" href="{{ '' | absolute_url }}">{{ site.title }}</a>
+    <a class="navbar-brand" href="{{ '/' base_url | absolute_url }}">{{ site.title }}</a>
   {%- endif -%}
 
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main-navbar" aria-controls="main-navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -42,7 +42,7 @@
   {% if site.avatar and page.show-avatar != false %}
     <div class="avatar-container">
       <div class="avatar-img-border">
-        <a href="{{ '' | absolute_url }}">
+        <a href="{{ '/' base_url | absolute_url }}">
           <img alt="Navigation bar avatar" class="avatar-img" src="{{ site.avatar | relative_url }}" />
         </a>
       </div>


### PR DESCRIPTION
When doing `jekyll build` (not serve) and the site.url and site.base_url are not configured, the home links would resolve as `href=""` (empty) and instead of returning home they would refresh the page instead.

Switching to `{{ '/' base_url | absolute_url }}">` will make them default to `href="/"` or `href="/[base_url]"` appropriately. I can't think of a situation where an empty href would be desired instead.

This change does not affect github pages and jekyll serve as the `absolute_url ` will not be null in those situations.