### PR TITLE
Restore feed link as a social network link

### DIFF
--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -1,6 +1,6 @@
 <ul class="list-inline text-center footer-links">
 
-{%- if site.rss-description -%}
+{%- if site.rss-description and site.share-links-active.rss -%}
   <li class="list-inline-item">
     <a href="{{ '/feed.xml' | relative_url }}" title="RSS">
       <span class="fa-stack fa-lg" aria-hidden="true">


### PR DESCRIPTION
In previous versions of the theme, the feed link would be alongside the other social links, [for example](https://cazzulino.com):

![image](https://user-images.githubusercontent.com/169707/118376542-ea949b80-b59e-11eb-8891-f88a6e631cc8.png)

This PR makes it possible (again) to enable it with:

```
share-links-active:
  feed: true
```

This aligns with the new mechanism for enabling those icons using the new `share-links-active` setting. 

See it in use at https://anycoder.net with the [config shown above](https://github.com/anycarvallo/anycarvallo.github.io/blob/main/_config.yml#L46).