### PR TITLE
Build page locally with `nix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ ehthumbs.db
 Gemfile.lock
 
 beautiful-jekyll-theme-*.gem
+
+# local build
+.jekyll-cache/
+.jekyll-metadata

--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ Visit the [Official website](http://beautifuljekyll.com/examples) to see sample 
 
 If you'd like to showcase yourself and join this list, [upgrading to the Individual plan](https://github.com/sponsors/daattali/sponsorships?&tier_id=7362) will give you that publicity plus some other rewards!
 
+# Build the site locally
+Locally building the site allows you to see changes before commiting them. This enables much faster iteration cycles for small or visual changes (think changes to css or colors). GitHub pages uses `jekyll` to build the page in `_site`.
+
+If you have `nix` installed (if not, see [here](https://nixos.org/guides/how-nix-works.html) what it is and how it works, and [here](https://nixos.org/guides/install-nix.html) for installation), you can build this page locally simply via executing `nix-shell`.
+
+Running `nix-shell` builds the `shell.nix`, which (locally, think virtual environment) installs `jekyll`, `jekyll-paginate` and starts the `jekyll`-server in incremental build mode. You can find your locally built page on `localhost:4000`.
+
+Initial page generation may take a few seconds. Changes to most files (`*.md`, `*.html`, `*.js`, `*.css`, ...), tend to take less than 0.2sec until you can see the changes when reloading the page in your browser (this is shorter than it takes me to switch from my editor to my browser).
+
+Changes to `_config.yml` will only be visible after you stop `nix-shell`/`jekyll` and delete the `_site`-folder before restarting the server.
+
+
 # FAQ and support
 
 Visit the [official FAQ page](https://beautifuljekyll.com/faq) for answers to commonly asked questions.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> { };
+
+mkShell {
+  buildInputs = [
+    jekyll
+    rubyPackages.jekyll-paginate
+  ];
+  shellHook = ''
+      exec jekyll serve --watch --incremental
+  '';
+}


### PR DESCRIPTION
This PR allows for locally building GitHub pages with `jekyll` and `nix`. It will look exactly like the one GitHub will build.

When having `nix` installed (find out more about nix [here](https://nixos.org/guides/how-nix-works.html) or see the install guide [here](https://nixos.org/guides/install-nix.html)), running `nix-shell` builds the `shell.nix`, which (locally, think virtual environment) installs `jekyll`, `jekyll-paginate` and starts the `jekyll`-server in incremental build mode.

Initial page generation takes about two seconds, incremental changes to files (`*.md`, `*.html`, `*.js`, `*.css`, ...), take about 0.2sec (on my 6yo laptop) to rebuild. Changes to `_config.yml` require a deletion of `_site` artifacts and restart.


 I'd appreciate a `hacktoberfest-accepted-label`. :)