### PR TITLE
Add discord to supported social networks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,6 +63,7 @@ social-network-links:
 #  mastodon: instance.url/@username
 #  ORCID: your ORCID ID
 #  google-scholar: your google scholar
+#  discord: invite/invite_code or users/userid 
 
 # If you want your website to generate an RSS feed, provide a description
 # The URL for the feed will be https://<your_website>/feed.xml

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -299,5 +299,17 @@
    </a>
   </li>
 {%- endif -%}
+  
+{%- if site.social-network-links.discord -%}
+  <li class="list-inline-item">
+    <a href="https://discord.gg/{{ site.social-network-links.discord }}" title="Discord">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-discord fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">Itchio</span>
+   </a>
+  </li>
+{%- endif -%}
 
 </ul>

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -302,12 +302,12 @@
   
 {%- if site.social-network-links.discord -%}
   <li class="list-inline-item">
-    <a href="https://discord.gg/{{ site.social-network-links.discord }}" title="Discord">
+    <a href="https://discord.com/{{ site.social-network-links.discord }}" title="Discord">
       <span class="fa-stack fa-lg" aria-hidden="true">
         <i class="fas fa-circle fa-stack-2x"></i>
         <i class="fab fa-discord fa-stack-1x fa-inverse"></i>
       </span>
-      <span class="sr-only">Itchio</span>
+      <span class="sr-only">Discord</span>
    </a>
   </li>
 {%- endif -%}


### PR DESCRIPTION
This adds the option to display a discord icon in the social network list.

you could either set this to for example invite/invite_code to get a link to your discord server or to users/userid to get a link to your discord profile where people could add you

apperantly this theme uses an old version of fontawesome and because of that it still displays the old discord logo