### PR TITLE
Updated Discord Link from .com to .gg

### DIFF
--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -302,7 +302,7 @@
   
 {%- if site.social-network-links.discord -%}
   <li class="list-inline-item">
-    <a href="https://discord.com/{{ site.social-network-links.discord }}" title="Discord">
+    <a href="https://discord.gg/{{ site.social-network-links.discord }}" title="Discord">
       <span class="fa-stack fa-lg" aria-hidden="true">
         <i class="fas fa-circle fa-stack-2x"></i>
         <i class="fab fa-discord fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
I don't know since when but new Discord invites use the `.gg` domain instead of `.com` one.