### PR TITLE
fix dropdown item text color

### DIFF
--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -259,6 +259,7 @@ img {
   white-space: normal;
   padding: 0.625rem;
   background-color: {{ site.navbar-col | default: "#EAEAEA" }};
+  color: {{ site.navbar-text-col | default: "#404040" }};
   text-decoration: none !important;
   border-width: 0 1px 1px 1px;
   font-weight: normal;


### PR DESCRIPTION
Fix dropdown item text color in the navigation bar to follow site.navbar-border-col (otherwise it inherits a default color from a bootstrap theme)