### PR TITLE
make LinkedIn link compatible with company pages

### DIFF
--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -98,7 +98,7 @@
 
 {%- if site.social-network-links.linkedin -%}
   <li class="list-inline-item">
-    <a href="https://linkedin.com/in/{{ site.social-network-links.linkedin }}" title="LinkedIn">
+    <a href="https://linkedin.com/{{ site.social-network-links.linkedin }}" title="LinkedIn">
       <span class="fa-stack fa-lg" aria-hidden="true">
         <i class="fas fa-circle fa-stack-2x"></i>
         <i class="fab fa-linkedin fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
Company pages on LinkedIn have urls such as https://www.linkedin.com/company/mycompany.
Removing /in/ allow such pages to be linked with beautiful jekyll
