### PR TITLE
footer-extra error

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,9 +3,9 @@
     <div class="row">
       <div class="col-xl-8 offset-xl-2 col-lg-10 offset-lg-1">
       {% include social-networks-links.html %}
-      {% if page.footer-extra %}
+      {% if site.footer-extra %}
         <div class="footer-custom-content">
-          {% for file in page.footer-extra %}
+          {% for file in site.footer-extra %}
             {% include {{ file }} %}
           {% endfor %}
         </div>


### PR DESCRIPTION
footer-extra was using page.footer-extra instead of site.footer-extra and was not working. Changed now to correct bug.

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
