### PR TITLE
Add "New Page" option for 404

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,7 +35,7 @@
         &nbsp;&bull;&nbsp;
         {% if page.path == '404.html' %}
           <script>
-            var fullurl = '{{ site.github.repository_url }}/new/{{ site.github.source.branch }}?filename='+window.location.pathname;
+            var fullurl = '{{ site.github.repository_url }}/new/{{ site.github.source.branch }}?filename='+window.location.pathname+'.md';
             document.write('<a title="Create this page on GitHub" href="' + fullurl + '" class="text_muted">New page</a>');
           </script>
         {% else %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,10 +31,17 @@
         {% endif %}
       {% endif%}
 
-      {% if site.edit_page_button and site.github.repository_url %}
+       {% if site.edit_page_button and site.github.repository_url %}
         &nbsp;&bull;&nbsp;
-        <a title="Edit this page on GitHub" href="{{ site.github.repository_url }}/edit/{{ site.github.source.branch }}/{{ page.path }}" class="text_muted">Edit page</a>
-       {% endif%}
+        {% if page.path == '404.html' %}
+          <script>
+            var fullurl = '{{ site.github.repository_url }}/new/{{ site.github.source.branch }}?filename='+window.location.pathname;
+            document.write('<a title="Create this page on GitHub" href="' + fullurl + '" class="text_muted">New page</a>');
+          </script>
+        {% else %}
+          <a title="Edit this page on GitHub" href="{{ site.github.repository_url }}/edit/{{ site.github.source.branch }}/{{ page.path }}" class="text_muted">Edit page</a>
+        {% endif %}
+        {% endif %}
 
       </p>
       {% unless site.remove-ads %}<p class="theme-by text-muted">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,7 +31,7 @@
         {% endif %}
       {% endif%}
 
-       {% if site.edit_page_button and site.github.repository_url %}
+      {% if site.edit_page_button and site.github.repository_url %}
         &nbsp;&bull;&nbsp;
         {% if page.path == '404.html' %}
           <script>
@@ -41,7 +41,7 @@
         {% else %}
           <a title="Edit this page on GitHub" href="{{ site.github.repository_url }}/edit/{{ site.github.source.branch }}/{{ page.path }}" class="text_muted">Edit page</a>
         {% endif %}
-        {% endif %}
+      {% endif %}
 
       </p>
       {% unless site.remove-ads %}<p class="theme-by text-muted">


### PR DESCRIPTION
Improvement on #1004

This should work, but it cannot distinguish new pages from new posts, i.e. When you try "abc.github.io/2022-07-14-abcde" it will just direct you to create a file called "2022-07-14-abcde" in root.

Example when the page does not exist (Notice the text in red boxes)

![20220714_00001](https://user-images.githubusercontent.com/11853019/178919539-026b1853-b5e7-4e09-9079-149c2005edf2.png)

