### PR TITLE
replaced `var` with `const` in Staticman script

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -3,27 +3,25 @@ layout: null
 ---
 
 (function ($) {
-  var $comments = $('.js-comments');
-
   $('#new_comment').submit(function () {
-    var form = this;
+    const form = this;
 
     $(form).addClass('disabled');
 
     {% assign sm = site.staticman -%}
-    var endpoint = '{{ sm.endpoint }}';
-    var repository = '{{ sm.repository }}';
-    var branch = '{{ sm.branch }}';
-    let url = endpoint + repository + '/' + branch + '/comments';
-    let data = $(this).serialize();
+    const endpoint = '{{ sm.endpoint }}';
+    const repository = '{{ sm.repository }}';
+    const branch = '{{ sm.branch }}';
+    const url = endpoint + repository + '/' + branch + '/comments';
+    const data = $(this).serialize();
 
-    var xhr = new XMLHttpRequest();
+    const xhr = new XMLHttpRequest();
     xhr.open("POST", url);
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     xhr.onreadystatechange = function () {
       if(xhr.readyState === XMLHttpRequest.DONE) {
-        var status = xhr.status;
+        const status = xhr.status;
         if (status >= 200 && status < 400) {
           formSubmitted();
         } else {


### PR DESCRIPTION
# Context

This is a follow-up of #1048 that I've raised.  I encourage others try replacing `var` by either `const` or `let` in other JS code.

# Discussion

Observe that in my Staticman script, once the variables are defined, they are never ~~changed~~ reassigned.

I've removed the line `var $comments = $('.js-comments');` because that's never used.  (c.f. mmistakes/minimal-mistakes#1996)

# Test

On [my fork](https://git.io/bjsm0)'s `gh-pages` branch (for [demo site](https://git.io/bjsm18)), dbde15b4's parent is a merge commit that incorporates this commit.