### PR TITLE
Allow html in share tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 
   {% capture title %}
     {%- if page.share-title -%}
-      {{ page.share-title | strip_html | xml_escape }}
+      {{ page.share-title | xml_escape }}
     {%- elsif page.title -%}
       {{ page.title | strip_html | xml_escape  }}
     {%- else -%}
@@ -14,7 +14,7 @@
 
   {% capture description %}
     {%- if page.share-description -%}
-      {{ page.share-description | strip_html | xml_escape }}
+      {{ page.share-description | xml_escape }}
     {%- elsif page.subtitle -%}
       {{ page.subtitle | strip_html | xml_escape }}
     {%- else -%}


### PR DESCRIPTION
This PR aims to allow use of html in the share-description and share-title yaml of the pages, to allow for styling in web search results and web page sharing.