### PR TITLE
Add GitLab to the list of social media sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - BREAKING CHANGE: Allow changing the order of the social network links that appear in the footer (#1152)
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
-- Added social network link for GitLab
+- Added social network link for GitLab (#1168)
 
 ## v6.0.1 (2023-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - BREAKING CHANGE: Allow changing the order of the social network links that appear in the footer (#1152)
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
+- Added social network link for GitLab
 
 ## v6.0.1 (2023-06-08)
 

--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,7 @@ social-network-links:
 #  discord: "invite_code" or "users/userid" or "invite/invite_code" 
 #  kaggle: yourname
 #  hackerrank: yourname
+#  gitlab: yourname
 
 # If you want your website to generate an RSS feed, provide a description
 # The URL for the feed will be https://<your_website>/feed.xml

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -75,6 +75,18 @@
   </li>
   {%- endif -%}
 
+  {%- if network[0] == "gitlab" -%}
+  <li class="list-inline-item">
+    <a href="https://gitlab.com/{{ network[1] }}" title="GitLab">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-gitlab fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">GitLab</span>
+   </a>
+  </li>
+  {%- endif -%}
+
   {%- if network[0] == "twitter" -%}
   <li class="list-inline-item">
     <a href="https://twitter.com/{{ network[1] }}" title="Twitter">


### PR DESCRIPTION
GitLab is also in font-awesome so adding support for it is pretty much a copy-paste from the GitHub entry. I just added it for my own website, but it should probably live upstream.