### PR TITLE
Add Support for front matter tag author: to add a by line to posts, with a hyperlink to the author's bio and posts

### DIFF
--- a/_authors/stephen.md
+++ b/_authors/stephen.md
@@ -1,0 +1,6 @@
+---
+username: stephen
+name: Stephen Schwetz
+bio: Emma's Number One Fan
+location: Newcastle, NSW, Australia
+---

--- a/_config.yml
+++ b/_config.yml
@@ -274,7 +274,15 @@ defaults:
     scope:
       path: "" # any file that's not a post will be a "page" layout by default
     values:
-      layout: "page"
+      layout: "page" 
+  - 
+    scope:
+      path: ""
+      type: authors #Create /authors/<author-names>.html
+    values:
+      layout: author
+      permalink: /authors/:slug
+
 
 # Exclude these files from production site
 exclude:
@@ -290,6 +298,10 @@ exclude:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+
+collections:
+  authors:
+    output: true #output authors web pages
 
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189

--- a/_config.yml
+++ b/_config.yml
@@ -255,7 +255,15 @@ timezone: "America/Toronto"
 markdown: kramdown
 highlighter: rouge
 permalink: /:year-:month-:day-:title/
-paginate: 5
+
+############################################################
+# Site configuration for the Jekyll 3 Pagination Gem
+# The values here represent the defaults if nothing is set
+pagination:
+  enabled: true
+  per_page: 5
+
+############################################################
 
 kramdown:
   input: GFM
@@ -296,7 +304,7 @@ exclude:
   - docs/
 
 plugins:
-  - jekyll-paginate
+  - jekyll-paginate-v2
   - jekyll-sitemap
 
 collections:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -37,8 +37,15 @@
             {% endif %}
           {% endif %}
 
-          {% if include.type == "post" %}
-            <span class="post-meta">Posted on {{ page.date | date: date_format }}</span>
+          {% if include.type == "post" %} 
+            <span class="post-meta">
+              Posted on {{ page.date | date: date_format }}
+              {% if page.author %} by: 
+                <a href="{{ absolute_url }}//authors/{{ page.author | strip_html | downcase }}.html">
+                  {{ page.author | strip_html }}
+                </a>
+              {% endif %}
+            </span>
             {% if page.last-updated %}
               <span class="post-meta">
                 <span class="d-none d-md-inline middot">&middot;</span>
@@ -72,7 +79,14 @@
           {% endif %}
 
           {% if include.type == "post" %}
-            <span class="post-meta">Posted on {{ page.date | date: date_format }}</span>
+            <span class="post-meta">
+              Posted on {{ page.date | date: date_format }}
+              {% if page.author %} by: 
+                <a href="{{ absolute_url }}//authors/{{ page.author | strip_html | downcase }}.html">
+                  {{ page.author | strip_html }}
+                </a>
+              {% endif %}
+            </span>
             {% if page.last-updated %}
               <span class="post-meta">
                 <span class="d-none d-md-inline middot">&middot;</span>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -1,0 +1,31 @@
+---
+layout: page
+title: {{ page.name }}
+---
+
+{% if page.picture %}
+    <center><img class="author-profile-image" src="/{{ page.picture }}" alt="{{ page.name }}" width="200" height="200" /></center>
+{% endif %}
+<h1 class="site-title">{{ page.name }}</h1>
+{% if page.bio %}
+    <div class="author-bio">{{ page.bio }}</div>
+{% endif %}
+{% if page.location %}
+    <div class="author-location">{{ page.location }}</div>
+{% endif %}
+
+{% assign number_of_posts = 0 %}
+{% for post in site.posts %}
+    {% if post.authors contains page.username or page.username == post.author %}
+        {% assign number_of_posts = number_of_posts | plus: 1 %}
+    {% endif %}
+{% endfor %}
+{% if number_of_posts == 0 %}No posts{% elsif number_of_posts == 1 %}1 post{% else %}{{ number_of_posts }} posts{% endif %}
+
+<ul>
+{% for post in site.posts %}
+    {% if post.authors contains page.username or page.username == post.author %}
+       <li> <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></li>
+    {% endif %}
+{% endfor %}
+</ul>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,10 +45,15 @@ layout: page
           </h3>
         {% endif %}
       </a>
-
+      
       <p class="post-meta">
         {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
         Posted on {{ post.date | date: date_format }}
+        {% if post.author %} by: 
+          <a href="{{ absolute_url }}/authors/{{ post.author | strip_html | downcase }}.html">
+            {{ post.author | strip_html }}
+          </a>
+        {% endif %}
       </p>
 
       {% if thumbnail != "" %}

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.3"
-  spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
+  spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
   spec.add_runtime_dependency "kramdown", "~> 2.3.2"

--- a/index.html
+++ b/index.html
@@ -1,4 +1,6 @@
 ---
+pagination: 
+  enabled: true
 layout: home
 title: My website
 subtitle: This is where I will tell my friends way too much about me


### PR DESCRIPTION
This pull request adds the ability to tag a post with an author's name by using the front matter author: field. 

this pull adds/changes 5 files:
* _config.yml - adds collection authors; adds scope for _author layout
* _authors/stephen.md - example author's file
* includes/header.html - adds logic to add link to posts
* _layouts/author.html - layout used to generate authors bio pages
* _layouts/home.html - adds by line to posts on the home page

_layouts/author.html needs some love to make it look pretty, UIX is not my forte.

### Example screenshot of home page post rendering with author

<img width="790" alt="image" src="https://github.com/daattali/beautiful-jekyll/assets/19428602/57aeee0e-0c86-43f7-a183-ec046878ffa0">

### Example screenshot of post rendering with author

<img width="963" alt="image" src="https://github.com/daattali/beautiful-jekyll/assets/19428602/4f7c5550-82af-45a9-8994-b76e4d5f11e9">


