### PR TITLE
Add Bluesky to social network links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 - BREAKING CHANGE: Allow changing the order of the social network links that appear in the footer (#1152)
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
-- Added social network link for GitLab (#1168)
+- Added social network links for GitLab, Bluesky (#1168, #1218)
 - Added instructions and example on how to fix image links in project sites (#1171)
-- Added social network link for Bluesky (#1218)
 
 ## v6.0.1 (2023-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
 - Added social network link for GitLab (#1168)
 - Added instructions and example on how to fix image links in project sites (#1171)
-- Added social network link for Bluesky
+- Added social network link for Bluesky (#1218)
 
 ## v6.0.1 (2023-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
 - Added social network link for GitLab (#1168)
 - Added instructions and example on how to fix image links in project sites (#1171)
+- Added social network link for Bluesky
 
 ## v6.0.1 (2023-06-08)
 

--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,7 @@ social-network-links:
 #  telegram: yourname
 #  calendly: yourname
 #  mastodon: instance.url/@username
+#  bluesky: yourname
 #  ORCID: your ORCID ID
 #  google-scholar: your google scholar
 #  discord: "invite_code" or "users/userid" or "invite/invite_code" 

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -255,6 +255,18 @@
   </li>
   {%- endif -%}
 
+  {%- if network[0] == "bluesky" -%}
+  <li class="list-inline-item">
+    <a rel="me" href="https://bsky.app/profile/{{ network[1] }}" title="Bluesky">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fas fa-square fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">Bluesky</span>
+    </a>
+  </li>
+  {%- endif -%}
+
   {%- if network[0] == "ORCID" -%}
  <li class="list-inline-item">
    <a href="https://orcid.org/{{ network[1] }}" title="ORCID">


### PR DESCRIPTION
Adds Bluesky as another possible social network link. 

Note I used the same FontAwesome icon (a simple square!) that Bluesky uses on its homepage:
https://blueskyweb.xyz/

The icon is discussed further here:
https://github.com/FortAwesome/Font-Awesome/issues/19810