### PR TITLE
Enable plugin jekyll-paginate-v2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased version
 
-- BREAKING CHANGE: upgrade to use jekyll-paginate-v2. This will require a "bundle install" and "bundle clean" for current self-hosted installs. This requires Jekyll 3.0 or later (which should be everyone)
+- Allow upgrade to use jekyll-paginate-v2. This will require a "bundle install" and "bundle clean" for current self-hosted installs and requires manual changes to enable. This requires Jekyll 3.0 or later (which should be everyone). This does **NOT** support github pages
 - BREAKING CHANGE: Allow changing the order of the social network links that appear in the footer (#1152)
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
 - Added social network links for GitLab, Bluesky (#1168, #1218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased version
 
+- BREAKING CHANGE: upgrade to use jekyll-paginate-v2. This will require a "bundle install" and "bundle clean" for current self-hosted installs. This requires Jekyll 3.0 or later (which should be everyone)
 - BREAKING CHANGE: Allow changing the order of the social network links that appear in the footer (#1152)
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156) 
 - Added social network link for GitLab (#1168)

--- a/_config.yml
+++ b/_config.yml
@@ -313,8 +313,8 @@ exclude:
   - docs/
 
 plugins:
-  - jekyll-paginate
-#  - jekyll-paginate-v2
+#  - jekyll-paginate
+  - jekyll-paginate-v2
   - jekyll-sitemap
 
 collections:

--- a/_config.yml
+++ b/_config.yml
@@ -257,12 +257,20 @@ markdown: kramdown
 highlighter: rouge
 permalink: /:year-:month-:day-:title/
 
-############################################################
-# Site configuration for the Jekyll 3 Pagination Gem
-# The values here represent the defaults if nothing is set
-pagination:
-  enabled: true
-  per_page: 5
+###############################################################################
+#           Site configuration for the Jekyll 3 Pagination Gem.               #
+#         The values here represent the defaults if nothing is set            #
+#                                                                             #
+#            This plugin is not supported on github pages.                    #
+#                                                                             #
+# You will also have to disable jekyll-paginate and enable jekyll-oaginate-v2 #
+# in the plugins configuration. You will need to edit the                     #
+# beautiful-jekyll-theme.gemspec to disable jeykell-paginate and enable       #
+# jeykll-paginate-v2                                                          #
+###############################################################################
+#pagination:
+#  enabled: true
+#  per_page: 5
 
 ############################################################
 
@@ -283,7 +291,15 @@ defaults:
     scope:
       path: "" # any file that's not a post will be a "page" layout by default
     values:
-      layout: "page"
+      layout: "page" 
+  - 
+    scope:
+      path: ""
+      type: authors #Create /authors/<author-names>.html
+    values:
+      layout: author
+      permalink: /authors/:slug
+
 
 # Exclude these files from production site
 exclude:
@@ -298,7 +314,12 @@ exclude:
 
 plugins:
   - jekyll-paginate
+#  - jekyll-paginate-v2
   - jekyll-sitemap
+
+collections:
+  authors:
+    output: true #output authors web pages
 
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189

--- a/_config.yml
+++ b/_config.yml
@@ -255,7 +255,15 @@ timezone: "America/Toronto"
 markdown: kramdown
 highlighter: rouge
 permalink: /:year-:month-:day-:title/
-paginate: 5
+
+############################################################
+# Site configuration for the Jekyll 3 Pagination Gem
+# The values here represent the defaults if nothing is set
+pagination:
+  enabled: true
+  per_page: 5
+
+############################################################
 
 kramdown:
   input: GFM

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,11 +4,9 @@ layout: page
 
 {{ content }}
 
-{% assign posts = paginator.posts | default: site.posts %}
-
 <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
 <ul class="posts-list list-unstyled" role="list">
-  {% for post in posts %}
+  {% for post in paginator.posts %}
   <li class="post-preview">
     <article>
 

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.3"
-  spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
+  spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
+  #spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
   spec.add_runtime_dependency "kramdown", "~> 2.3.2"

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.3"
-  spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   #spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.3"
-  spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
+  spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
   spec.add_runtime_dependency "kramdown", "~> 2.3.2"

--- a/index.html
+++ b/index.html
@@ -1,4 +1,6 @@
 ---
+pagination: 
+  enabled: true
 layout: home
 title: My website
 subtitle: This is where I will tell my friends way too much about me


### PR DESCRIPTION
This paginator was released with Jeykll v3.0 and depreciated the original Jekyll-paginate. It is fully backwards compatible with the original paginator, with the only difference being that it needs to be enabled on pages that you wish to have paginated (i.e. /index.html).

This paginator has many more features than the original including the support for pages and posts, as well as categories, and tags.

It can also auto-generate category and tag pages.