### PR TITLE
Set Pagination buttons to show left and right arrows instead of text newer and older

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -101,12 +101,22 @@ layout: page
 <ul class="pagination main-pager">
   {% if paginator.previous_page %}
   <li class="page-item previous">
-    <a class="page-link" href="{{ paginator.previous_page_path | absolute_url }}">&larr; Newer Posts</a>
+    <a class="page-link" href="{{ paginator.previous_page_path | absolute_url }}">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fas fa-arrow-left fa-stack-1x fa-inverse" alt="Newer Posts"></i>
+      </span>
+    </a>
   </li>
   {% endif %}
   {% if paginator.next_page %}
   <li class="page-item next">
-    <a class="page-link" href="{{ paginator.next_page_path | absolute_url }}">Older Posts &rarr;</a>
+    <a class="page-link" href="{{ paginator.next_page_path | absolute_url }}">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fas fa-arrow-right fa-stack-1x fa-inverse" alt="Older Posts"></i>
+      </span>
+    </a>
   </li>
   {% endif %}
 </ul>


### PR DESCRIPTION
This pull request updates _layout/home.html to replace the current paginator navigation buttons from words "newer" and "older" with font-awesome arrow icons. The image below shows the styling of an inactive button (left arrow) and one that has a mouse over (right arrow)

I was tossing up the idea of making the format of the icons the same as the others in the footer but decided on this format instead, as it makes them a little more obvious

<img width="813" alt="image" src="https://github.com/daattali/beautiful-jekyll/assets/19428602/8335538b-7b6f-48dc-9538-5329b297c3e2">
