### PR TITLE
Add robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,3 +2,6 @@
 layout: none
 ---
 Sitemap: {{ "sitemap.xml" | absolute_url }}
+
+User-agent: *
+Allow: /


### PR DESCRIPTION
This will add a robots.txt file to the root of the website.

As the theme generates a sitemap.xml, I am declaring it's location as per spec to assist with the site being spidered without having to go to every search engine and add yourself to their webmaster tools.

This should help with new starters getting their sites into the rankings, buy today and ill throw in a free set of steak knives.