### PR TITLE
Made the footer stick to the bottom; fixes #576

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased version
 - BREAKING CHANGE: Allow changing the order of the social network links that appear in the footer (#1152)
 - BREAKING CHANGE: `google-scholar` social network link no longer requires the prefix `citations?user=`; if you previously set this parameter, it needs to be updated (#1189)
+- The footer of a page always sticks to the bottom, even on short pages (#576)
 - Added `author` YAML parameter to allow specifying the author(s) of a post (#1220)
 - Fixed bug where hovering over search results showed the text "{desc}" (#1156)
 - Added social network links for GitLab, Bluesky (#1168, #1218)

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -34,7 +34,6 @@ common-js:
   </div>
 
   {% include footer.html %}
-  
 
   {% include footer-scripts.html %}
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -25,14 +25,16 @@ common-js:
 {% include head.html %}
 
 <body>
+  <div>
+    {% include gtm_body.html %}
 
-  {% include gtm_body.html %}
+    {% include nav.html %}
 
-  {% include nav.html %}
-
-  {{ content }}
+    {{ content }}
+  </div>
 
   {% include footer.html %}
+  
 
   {% include footer-scripts.html %}
 

--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -21,6 +21,9 @@ body {
   background-attachment: fixed;
   {% endif %}
   overflow-wrap: break-word;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: 1fr auto;
 }
 p {
   line-height: 1.5;


### PR DESCRIPTION
Makes the footer stick to the bottom when the content isn't enough to push the footer past the screen using CSS grids.