### PR TITLE
Add itch.io social network link to the commented out entries

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,7 @@ social-network-links:
 #  kaggle: yourname
 #  hackerrank: yourname
 #  gitlab: yourname
+#  itchio: yourname
 
 # If you want your website to generate an RSS feed, provide a description
 # The URL for the feed will be https://<your_website>/feed.xml


### PR DESCRIPTION
As the title implies, this PR adds a itch.io entry to the social network links along with all the others that are commented out. I actually didn't know that this template supported itch.io as social network link, since I only looked in the `_config.yml` and though the ones present there were the only ones available. So I think adding it there will make it somewhat less obscure.