### PR TITLE
Move hard version constraint to Gemfile to allow gem to run on 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@
 
 source "https://rubygems.org"
 
-gemspec
 
+gemspec
+gem 'jekyll', '~> 3.9.3'

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     "documentation_uri" => "https://github.com/daattali/beautiful-jekyll#readme"
   }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.9.3"
+  spec.add_runtime_dependency "jekyll", ">= 3.9.3"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"


### PR DESCRIPTION
Hi @daattali - thank you for an amazing theme!

I was using version 6.0.1 with a Jekyll 4.3.3 site and it was working fine, but I needed some of the fixes that have been made since then (for example, a206f70), so I tried to switch to using the latest master on my site and that's when I fell foul of 1758870, which forces the version to 3.x.

The gem works fine with 4.x in my limited testing, so would it be possible to restore support for 4.x? Perhaps if the constraint is just for GH Actions, it could be moved out of the gemspec and into the `Gemfile`? Here is a PR to that effect.

Thanks so much!