### PR TITLE
Add a title-on-all-pages site option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added instructions and example on how to fix image links in project sites (#1171)
 - Pagination buttons: use nicer arrows, and don't show text on small screens (#1221)
 - Updated Yelp URL format - if you previously used the `yelp` social network config parameter, you might need to update the config value (#1259)
+- Added `title-on-all-pages` config setting, that adds the website title to all page titles
 
 ## v6.0.1 (2023-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added instructions and example on how to fix image links in project sites (#1171)
 - Pagination buttons: use nicer arrows, and don't show text on small screens (#1221)
 - Updated Yelp URL format - if you previously used the `yelp` social network config parameter, you might need to update the config value (#1259)
-- Added `title-on-all-pages` config setting, that adds the website title to all page titles
+- Added `title-on-all-pages` config setting, that adds the website title to all page titles (#1272)
 
 ## v6.0.1 (2023-06-08)
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@
 
 # Name of website
 title: My Website
+# Show the site title in the <title> of all pages in addition to the page title
+title_on_all_pages: false
 
 # Your name to show in the footer
 author: Some Person

--- a/_config.yml
+++ b/_config.yml
@@ -10,9 +10,9 @@
 ############################
 
 # Name of website
-title: My Website
+title: My website
 # Show the site title in the <title> of all pages in addition to the page title
-title_on_all_pages: false
+title-on-all-pages: true
 
 # Your name to show in the footer
 author: Some Person

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@
 
 # Name of website
 title: My website
+
 # Show the site title in the <title> of all pages in addition to the page title
 title-on-all-pages: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -12,9 +12,6 @@
 # Name of website
 title: My website
 
-# Show the site title in the <title> of all pages in addition to the page title
-title-on-all-pages: true
-
 # Your name to show in the footer
 author: Some Person
 
@@ -102,6 +99,9 @@ share-links-active:
 # How to display the link to your website in the footer
 # Remove this if you don't want a link in the footer
 url-pretty: "MyWebsite.com"
+
+# Show the site title in the <title> of all pages in addition to the page title
+title-on-all-pages: true
 
 # Excerpt word length - Truncate the excerpt of each post on the feed page to the specified number of words
 excerpt_length: 50

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,7 @@
   {% endcapture %}
 
   {% capture title %}
-    {%- if site.title_on_all_pages and (site.title != pagetitle) -%}
+    {%- if site.title and site.title-on-all-pages and (site.title != pagetitle) -%}
       {{ pagetitle }} | {{ site.title }}
     {%- else -%}
       {{ pagetitle }}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,13 +2,21 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  {% capture title %}
+  {% capture pagetitle %}
     {%- if page.share-title -%}
       {{ page.share-title | strip_html | xml_escape }}
     {%- elsif page.title -%}
       {{ page.title | strip_html | xml_escape  }}
     {%- else -%}
       {{ site.title | strip_html | xml_escape }}
+    {%- endif -%}
+  {% endcapture %}
+
+  {% capture title %}
+    {%- if site.title_on_all_pages and (site.title != pagetitle) -%}
+      {{ pagetitle }} | {{ site.title }}
+    {%- else -%}
+      {{ pagetitle }}
     {%- endif -%}
   {% endcapture %}
 


### PR DESCRIPTION
This PR adds a site option called `title_on_all_pages` - it adds the `site.title` to the end of all page titles (separated by `|`), unless the `site.title` and `title` are the same string (usually on home pages).

This still contains my commit from #1270 but if you like the idea, and the variable name, I'll tidy it up and remove that commit before you accept it. No worries if you don't want this option in your theme!