### PR TITLE
Fix GitHub Actions for Jekyll 4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,23 @@ jobs:
   build:
     name: Build Jekyll
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_version: ['3.3']
+        jekyll_version: ['3.9.4', '4.3.3']
     steps:
       - uses: actions/checkout@v3
-      - name: Build the site in the jekyll/builder container
-        run: |
-          export JEKYLL_VERSION=3.8
-          docker run \
-          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-          -e PAGES_REPO_NWO=${{ github.repository }} \
-          jekyll/builder:$JEKYLL_VERSION /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - name: Install the specified version of Jekyll
+        run: gem install -v ${{ matrix.jekyll_version }} jekyll
+      - name: Install dependencies
+        run: bundle install --without=jekyll
+      - name: Build site
+        run: bundle exec jekyll build --future
+      - name: Capture built site as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-ruby${{ matrix.ruby_version}}-jekyll${{ matrix.jekyll_version }}
+          path: _site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,23 +4,12 @@ jobs:
   build:
     name: Build Jekyll
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby_version: ['3.3']
-        jekyll_version: ['3.9.4', '4.3.3']
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby_version }}
-      - name: Install the specified version of Jekyll
-        run: gem install -v ${{ matrix.jekyll_version }} jekyll
+          ruby-version: '3.3'
       - name: Install dependencies
-        run: bundle install --without=jekyll
+        run: bundle install && bundle exec appraisal install
       - name: Build site
-        run: bundle exec jekyll build --future
-      - name: Capture built site as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-ruby${{ matrix.ruby_version}}-jekyll${{ matrix.jekyll_version }}
-          path: _site
+        run: bundle exec appraisal jekyll build --future

--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,6 @@
+appraise "jekyll-3" do
+  gem "jekyll", "3.9.4"
+end
+appraise "jekyll-4" do
+  gem "jekyll", "4.3.3"
+end

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     "documentation_uri" => "https://github.com/daattali/beautiful-jekyll#readme"
   }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.9.3"
+  spec.add_runtime_dependency "jekyll", ">= 3.9.3"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "appraisal", "~> 2.5"
 end


### PR DESCRIPTION
Hi @daattali - instead of papering over the issue with my previous fix in #1270, I decided to do a deep dive into why GitHub Actions was failing with the relaxed version constraint and fix that instead.

The reason is because it depended on the Docker image `jekyll/builder:3.8`, which installs Jekyll 3.8.x, but the version constraint required at least 3.9.3. This meant bundler would install the latest version that matched the constraint over the top of the 3.8.x in the image. If that was a 4.x then it would fail because 4.x depends on `sass-embedded` which is not supported by the version of Rubygems in the `jekyll/builder:3.8`. Unfortunately, [jekyll/builder is no longer maintained](https://github.com/envygeeks/jekyll-docker/issues/364) and consequently there is no image for the 3.9.x strand.

Instead, I've switched to a GitHub action based on the `ruby/setup-ruby` action which is supported by GitHub themselves, and layered on top an [appraisal](https://github.com/thoughtbot/appraisal) which allows the CI to build both the 3.9.x version and the 4.3.x version and only pass if _both_ of them build.

How does this look to you? Hopefully it ensures that GH Pages will still build but also ensures that the 4.x branch builds for those of us who are using it.