### PR TITLE
Relax version constraint for kramdown

### DIFF
--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
-  spec.add_runtime_dependency "kramdown", "~> 2.3.2"
+  spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "webrick", "~> 1.8"
 
   spec.add_development_dependency "bundler", ">= 1.16"


### PR DESCRIPTION
Hi @daattali 

Versions of the `github-pages` gem after 229 depend on `kramdown` version 2.4.x. This PR relaxes the version constraint to ensure people can update to the latest version of `github-pages`. It should still work exactly the same with earlier versions too.
