### PR TITLE
Added Whatsapp to social network

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ social-network-links:
   twitter: daattali
   patreon: DeanAttali
   youtube: "@daattali"
+  whatsapp: 15551212
 #  medium: yourname
 #  reddit: yourname
 #  linkedin: daattali

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -65,7 +65,7 @@
 
   {%- if network[0] == "whatsapp" -%}
   <li class="list-inline-item">
-    <a href="https://t.me/{{ network[1] }}" title="Whatsapp">
+    <a href="https://wa.me/{{ network[1] }}" title="Whatsapp">
       <span class="fa-stack fa-lg" aria-hidden="true">
         <i class="fas fa-circle fa-stack-2x"></i>
         <i class="fab fa-whatsapp fa-stack-1x fa-inverse"></i>

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -63,6 +63,18 @@
   </li>
   {%- endif -%}
 
+  {%- if network[0] == "whatsapp" -%}
+  <li class="list-inline-item">
+    <a href="https://t.me/{{ network[1] }}" title="Whatsapp">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-whatsapp fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">Whatsapp</span>
+    </a>
+  </li>
+  {%- endif -%}
+
   {%- if network[0] == "github" -%}
   <li class="list-inline-item">
     <a href="https://github.com/{{ network[1] }}" title="GitHub">


### PR DESCRIPTION
Adding Whatsapp to social networks. Especially useful on mobile devices to launch whatsapp directly with the correct phone number.
