### PR TITLE
add configurable rotate time for header images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -125,6 +125,9 @@ edit_page_button: true
 # See https://github.com/daattali/beautiful-jekyll/issues/765 to understand the issue this setting can solve
 navbar-var-length: false
 
+# Time in milliseconds for how often the header images rotate.
+header-img-rotate-ms: 6000
+
 # The keywords to associate with your website, for SEO purposes
 #keywords: "my,list,of,keywords"
 

--- a/assets/js/beautifuljekyll.js
+++ b/assets/js/beautifuljekyll.js
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 // Dean Attali / Beautiful Jekyll 2023
 
 let BeautifulJekyllJS = {
@@ -82,7 +85,7 @@ let BeautifulJekyllJS = {
             getNextImg();
           }, 1000);
           //});
-        }, 6000);
+        }, {{ site.header-img-rotate-ms }});
       };
 
       // If there are multiple images, cycle through them


### PR DESCRIPTION
Adding the ability to define a different timeout for the banner image rotation. Defaults to 6000 like before, but allows users of the theme to configure a different value.