### PR TITLE
ci(workflow): ensure relative_url is used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,16 @@ jobs:
           ruby-version: '3.3'
       - name: Install dependencies
         run: bundle install && bundle exec appraisal install
+      - name: Setup Pages
+        id: configure-pages
+        uses: actions/configure-pages@v5
+      - name: Setup CI config
+        run: |
+          echo "---" > _config_ci.yml
+          echo "baseurl: ${{ steps.configure-pages.outputs.base_path }}" >> _config_ci.yml
       - name: Build site
-        run: bundle exec appraisal jekyll build --future
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec appraisal jekyll build --future --config _config_ci.yml,_config.yml
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The CI build does not respect the `relative_url` property when building from a "project" repo instead of the `.github.io` named repo.

Fixes #1373

The changes are derived from the examples here (https://github.com/actions/jekyll-build-pages) and were tested here (https://github.com/ReenigneArcher/beautiful-jekyll/pull/3). A small bug was found where those changes would not run certain plugins, such as those in a `_plugins` directory, so I reverted some of the changes, and made some tweaks in https://github.com/ReenigneArcher/beautiful-jekyll/pull/4. The changes in this repo are slightly different than from those two PRs, as the the deploy step is omitted.

The majority of people using beautiful-jekyll will probably never notice this issue because they are probably either using the repo named `.github.io` or are not using the workflow to build and deploy the pages.

Evidence of functionality: https://reenignearcher.github.io/beautiful-jekyll/ (I am deploying from the CI workflow, not from a branch) https://github.com/ReenigneArcher/beautiful-jekyll/actions/runs/10823491697