### PR TITLE
Add sitemap.xml

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 layout: default
 title: 404 - Page not found
 permalink: /404.html
+sitemap: false
 ---
 
 <div class="text-center">

--- a/_config.yml
+++ b/_config.yml
@@ -277,11 +277,18 @@ defaults:
       layout: "post"
       comments: true  # add comments to all blog posts
       social-share: true # add social media sharing buttons to all blog posts
+      sitemap: true # add blog posts to the sitemap
   -
     scope:
       path: "" # any file that's not a post will be a "page" layout by default
     values:
       layout: "page"
+      sitemap: true # add pages to the sitemap
+  - 
+    scope:
+      path: "assets/*"
+    values:
+      sitemap: false # don't include assets in the sitemap
 
 # Exclude these files from production site
 exclude:

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,6 @@
 ---
 layout: null
+sitemap: false
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,28 @@
+---
+layout: null
+sitemap: false
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- site's landing/home page will already be in site.pages -->
+  {% for page in site.pages %}
+    {% if page.sitemap %}
+  <url>
+    <loc>{{ site.url }}{{ site.baseurl }}{{ page.url }}</loc>
+    <lastmod>{{ site.time | date_to_xmlschema}}</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+    {% endif %}
+  {% endfor %}  
+  {% for post in site.posts %}
+    {% if post.sitemap %}
+  <url>
+    <loc>{{ site.url }}{{ site.baseurl }}{{ post.url }}</loc>
+    <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+   </url>
+    {% endif %}
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
This helps with SEO. We index all content by default (pages and posts),
unless explicitly opted-out via the `sitemap: false` front-matter.

We also exclude all static assets by default, since it's typically
made up of data, js, css and images which are typically not indexed either.