### PR TITLE
Add missing windows extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,15 @@
 
 source "https://rubygems.org"
 
-gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
-
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do
-    gem "tzinfo", ">= 1", "< 3"
-    gem "tzinfo-data"
-  end
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
   
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,14 @@
 
 source "https://rubygems.org"
 
+gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+    gem "tzinfo", ">= 1", "< 3"
+    gem "tzinfo-data"
+  end
+  
 gemspec
 


### PR DESCRIPTION
When running on Windows, wdm is required in order to properly do incremental updates and regeneration.

The tzinfo-data dependency is also reported missing (under Windows at least, with jekyll 3.9.3).