### PR TITLE
ci(build): fix baseurl when basepath is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
       - name: Setup CI config
         run: |
           echo "---" > _config_ci.yml
-          echo "baseurl: ${{ steps.configure-pages.outputs.base_path }}" >> _config_ci.yml
+          echo "baseurl: '${{ steps.configure-pages.outputs.base_path }}'" >> _config_ci.yml
       - name: Build site
         env:
           JEKYLL_ENV: production
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAGES_REPO_NWO: ${{ github.repository }}
         run: bundle exec appraisal jekyll build --future --config _config_ci.yml,_config.yml
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
I discovered a bug in this code when building from a main project, instead of a subproject. If the `base_path` evaluates to empty, then the `_config_ci.yml` syntax is invalid, so this fix wraps the value in single quotes to ensure it is valid whether it is empty or not.

Additionally, the env variables added help Jekyll detect github metadata (I think for the edit button).