### PR TITLE
add charset attribute to script tag for simple-jekyll-search

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -6,7 +6,7 @@
   <input type="text" id="nav-search-input" placeholder="Search">
   <ul id="search-results-container"></ul>
   
-  <script src="https://unpkg.com/simple-jekyll-search@latest/dest/simple-jekyll-search.min.js"></script>
+  <script src="https://unpkg.com/simple-jekyll-search@latest/dest/simple-jekyll-search.min.js" charset="utf-8"></script>
   <script>
     SimpleJekyllSearch({
       searchInput: document.getElementById('nav-search-input'),


### PR DESCRIPTION
This PR adds the `charset="utf-8"` attribute to the `<script>` tag for `simple-jekyll-search`. This update ensures proper support for multilingual search.