### PR TITLE
Add margin-bottom to social media links

### DIFF
--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -440,7 +440,10 @@ footer a:focus {
 footer .list-inline {
   margin: 0;
   padding: 0;
-  margin-bottom: 1.875rem;
+  margin-bottom: 1.375rem;
+}
+footer .list-inline .list-inline-item {
+  margin-bottom: 0.5rem;
 }
 footer .copyright {
   font-family: var(--header-font);


### PR DESCRIPTION
The social media links at the bottom of the page lack a margin-bottom meaning that when there are many of them and they spill onto a second line, there is no space between the rows, and this looks ugly. This change adds a suitable margin and also reduces the footer's overall margin-bottom to match the increase in item margin-bottom.
