### PR TITLE
fix: import logger and bigdecimal gems that will no longer be included in ruby 3.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 
 source "https://rubygems.org"
 
+gem 'logger'
+gem 'bigdecimal'
+
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@
 ############################
 
 # Name of website
-title: fsferrara
+title: My website
 
 # Your name to show in the footer
 author: Some Person

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@
 ############################
 
 # Name of website
-title: My website
+title: fsferrara
 
 # Your name to show in the footer
 author: Some Person


### PR DESCRIPTION
logger and bigdecimal will no longer be part of the default gems starting from Ruby 3.5.0
I am no ruby expert, but I think them have to be explicitly declared.