### PR TITLE
Add Knocket free live chat widget (opt-in)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -192,6 +192,10 @@ footer-hover-col: "#0085A1"
 # you should switch to using the `gtag` field above instead.
 #google_analytics: "UA-XXXXXXXX-X"
 
+# Knocket free live chat widget — https://trtc.io/solutions/knocket
+# Uncomment and fill in your identifier to enable. Free forever, no seat limits.
+#knocket_identifier: ""
+
 ####################
 # --- Comments --- #
 ####################

--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -36,3 +36,7 @@
     <script src="{{ js | relative_url }}"></script>
   {% endfor %}
 {% endif %}
+
+{% if site.knocket_identifier %}
+<script src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.knocket_identifier }}" async></script>
+{% endif %}

--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -37,6 +37,6 @@
   {% endfor %}
 {% endif %}
 
-{% if site.knocket_identifier %}
-<script src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.knocket_identifier }}" async></script>
+{% if site.knocket_identifier and site.knocket_identifier != "" %}
+<script src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.knocket_identifier | url_encode }}" async></script>
 {% endif %}


### PR DESCRIPTION
Adds an opt-in Knocket live chat widget. Knocket is a 100% free live chat widget (one script tag) — free forever, no ads, no seat limits. Disabled by default; renders only when knocket_identifier is set in _config.yml. Same pattern as the existing Tawk/analytics integrations. More info: https://trtc.io/solutions/knocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional live chat support for the site.
  * Chat loading is now controlled by a site setting, so it only appears when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->